### PR TITLE
Support LZ4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ libraryDependencies += "de.lhns" %% "fs2-compress-tar" % "2.0.0"
 libraryDependencies += "de.lhns" %% "fs2-compress-bzip2" % "2.0.0"
 libraryDependencies += "de.lhns" %% "fs2-compress-zstd" % "2.0.0"
 libraryDependencies += "de.lhns" %% "fs2-compress-brotli" % "2.0.0"
+libraryDependencies += "de.lhns" %% "fs2-compress-lz4" % "2.0.1"
 ```
 
 ### Example

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ val V = new {
   val commonsCompress = "1.27.1"
   val fs2 = "3.11.0"
   val logbackClassic = "1.5.8"
+  val lz4 = "1.8.0"
   val munitCatsEffect = "2.0.0"
   val zip4j = "2.11.5"
   val zstdJni = "1.5.6-5"
@@ -82,6 +83,7 @@ lazy val root: Project =
     .aggregate(zstd.projectRefs: _*)
     .aggregate(bzip2.projectRefs: _*)
     .aggregate(brotli.projectRefs: _*)
+    .aggregate(lz4.projectRefs: _*)
 
 lazy val core = projectMatrix
   .in(file("core"))
@@ -182,6 +184,19 @@ lazy val brotli = projectMatrix
     libraryDependencies ++= Seq(
       "co.fs2" %%% "fs2-io" % V.fs2,
       "org.brotli" % "dec" % V.brotli
+    )
+  )
+  .jvmPlatform(scalaVersions)
+
+lazy val lz4 = projectMatrix
+  .in(file("lz4"))
+  .dependsOn(core % "compile->compile;test->test")
+  .settings(commonSettings)
+  .settings(
+    name := "fs2-compress-lz4",
+    libraryDependencies ++= Seq(
+      "co.fs2" %%% "fs2-io" % V.fs2,
+      "org.lz4" % "lz4-java" % V.lz4
     )
   )
   .jvmPlatform(scalaVersions)

--- a/lz4/src/main/scala/de/lhns/fs2/compress/Lz4Compressor.scala
+++ b/lz4/src/main/scala/de/lhns/fs2/compress/Lz4Compressor.scala
@@ -1,0 +1,51 @@
+package de.lhns.fs2.compress
+
+import net.jpountz.lz4.{LZ4FrameOutputStream, LZ4FrameInputStream}
+import cats.effect.Async
+import fs2.Pipe
+import fs2.io._
+
+import java.io.{BufferedInputStream, OutputStream}
+
+class Lz4Compressor[F[_]: Async] private (chunkSize: Int) extends Compressor[F] {
+  override def compress: Pipe[F, Byte, Byte] = { stream =>
+    readOutputStream[F](chunkSize) { outputStream =>
+      stream
+        .through(writeOutputStream(Async[F].blocking[OutputStream] {
+          new LZ4FrameOutputStream(outputStream, LZ4FrameOutputStream.BLOCKSIZE.SIZE_256KB)
+        }))
+        .compile
+        .drain
+    }
+  }
+}
+
+object Lz4Compressor {
+  def apply[F[_]](implicit instance: Lz4Compressor[F]): Lz4Compressor[F] = instance
+
+  def make[F[_]: Async](
+      chunkSize: Int = Defaults.defaultChunkSize
+  ): Lz4Compressor[F] =
+    new Lz4Compressor(chunkSize)
+}
+
+class Lz4Decompressor[F[_]: Async] private (chunkSize: Int) extends Decompressor[F] {
+  override def decompress: Pipe[F, Byte, Byte] = { stream =>
+    stream
+      .through(toInputStream[F])
+      .map(new BufferedInputStream(_, chunkSize))
+      .flatMap { inputStream =>
+        readInputStream(
+          Async[F].blocking(new LZ4FrameInputStream(inputStream)),
+          chunkSize
+        )
+      }
+  }
+}
+
+object Lz4Decompressor {
+  def apply[F[_]](implicit instance: Lz4Decompressor[F]): Lz4Decompressor[F] = instance
+
+  def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): Lz4Decompressor[F] =
+    new Lz4Decompressor(chunkSize)
+}

--- a/lz4/src/test/scala/de/lhns/fs2/compress/Lz4RoundTripSuite.scala
+++ b/lz4/src/test/scala/de/lhns/fs2/compress/Lz4RoundTripSuite.scala
@@ -1,0 +1,29 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+class Lz4RoundTripSuite extends CatsEffectSuite {
+  implicit val lz4Compressor: Lz4Compressor[IO] = Lz4Compressor.make()
+  implicit val lz4Decompressor: Lz4Decompressor[IO] = Lz4Decompressor.make()
+
+  test("lz4 round trip") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024 * 1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(Lz4Compressor[IO].compress)
+        .through(Lz4Decompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}


### PR DESCRIPTION
This is using the frame encoding because that is what LZ4 files normally use.
Note that this is _not_ compatible with Apache Spark.