### PR TITLE
Add Brotli4J submodule

### DIFF
--- a/brotli4j/src/main/scala/de/lhns/fs2/compress/Brotli4J.scala
+++ b/brotli4j/src/main/scala/de/lhns/fs2/compress/Brotli4J.scala
@@ -1,0 +1,56 @@
+package de.lhns.fs2.compress
+
+import cats.effect.Async
+import com.aayushatharva.brotli4j.Brotli4jLoader
+import com.aayushatharva.brotli4j.encoder.{BrotliOutputStream, Encoder}
+import com.aayushatharva.brotli4j.decoder.BrotliInputStream
+import fs2.{Pipe, Stream}
+import fs2.io._
+
+class Brotli4JCompressor[F[_]: Async] private (chunkSize: Int, params: Encoder.Parameters) extends Compressor[F] {
+  override def compress: Pipe[F, Byte, Byte] = { stream =>
+    Stream.exec(Async[F].blocking(Brotli4jLoader.ensureAvailability())).covaryOutput[Byte] ++
+      readOutputStream[F](chunkSize) { outputStream =>
+        stream
+          .through(
+            writeOutputStream[F](Async[F].blocking(new BrotliOutputStream(outputStream, params)))
+          )
+          .compile
+          .drain
+      }
+  }
+}
+
+object Brotli4JCompressor {
+  def apply[F[_]](implicit instance: Brotli4JCompressor[F]): Brotli4JCompressor[F] = instance
+
+  def make[F[_]: Async](
+      chunkSize: Int = Defaults.defaultChunkSize,
+      params: Encoder.Parameters = Encoder.Parameters.DEFAULT
+  ): Brotli4JCompressor[F] =
+    new Brotli4JCompressor(chunkSize, params)
+}
+
+class Brotli4JDecompressor[F[_]: Async] private (chunkSize: Int) extends Decompressor[F] {
+  override def decompress: Pipe[F, Byte, Byte] = { stream =>
+    Stream.exec(Async[F].blocking(Brotli4jLoader.ensureAvailability())).covaryOutput[Byte] ++
+      stream
+        .through(toInputStream[F])
+        .flatMap { inputStream =>
+          readInputStream(
+            Async[F].blocking(new BrotliInputStream(inputStream)),
+            chunkSize
+          )
+        }
+  }
+}
+
+object Brotli4JDecompressor {
+  // Defined as DEFAULT_BUFFER_SIZE in BrotliInputStream, but isn't public
+  def defaultChunkSize: Int = 16384
+
+  def apply[F[_]](implicit instance: Brotli4JDecompressor[F]): Brotli4JDecompressor[F] = instance
+
+  def make[F[_]: Async](chunkSize: Int = defaultChunkSize): Brotli4JDecompressor[F] =
+    new Brotli4JDecompressor(chunkSize)
+}

--- a/brotli4j/src/test/scala/de/lhns/fs2/compress/Brotli4JRoundtripSuite.scala
+++ b/brotli4j/src/test/scala/de/lhns/fs2/compress/Brotli4JRoundtripSuite.scala
@@ -1,0 +1,29 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+class Brotli4JRoundtripSuite extends CatsEffectSuite {
+  implicit val brotliCompressor: Brotli4JCompressor[IO] = Brotli4JCompressor.make()
+  implicit val brotliDecompressor: Brotli4JDecompressor[IO] = Brotli4JDecompressor.make()
+
+  test("brotli round trip") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024 * 1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(Brotli4JCompressor[IO].compress)
+        .through(Brotli4JDecompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ name := (core.projectRefs.head / name).value
 val V = new {
   val betterMonadicFor = "0.3.1"
   val brotli = "0.1.2"
+  val brotli4j = "1.17.0"
   val catsEffect = "3.5.4"
   val commonsCompress = "1.27.1"
   val fs2 = "3.11.0"
@@ -184,6 +185,19 @@ lazy val brotli = projectMatrix
     libraryDependencies ++= Seq(
       "co.fs2" %%% "fs2-io" % V.fs2,
       "org.brotli" % "dec" % V.brotli
+    )
+  )
+  .jvmPlatform(scalaVersions)
+
+lazy val brotli4j = projectMatrix
+  .in(file("brotli4j"))
+  .dependsOn(core % "compile->compile;test->test")
+  .settings(commonSettings)
+  .settings(
+    name := "fs2-compress-brotli4j",
+    libraryDependencies ++= Seq(
+      "co.fs2" %%% "fs2-io" % V.fs2,
+      "com.aayushatharva.brotli4j" % "brotli4j" % V.brotli4j
     )
   )
   .jvmPlatform(scalaVersions)


### PR DESCRIPTION
The official brotli JVM implementation only supports decompression. In order to support compression we introduce a new module that uses Brotli4J(https://github.com/hyperxpro/Brotli4j) instead. See also discussion: https://github.com/lhns/fs2-compress/pull/151

Solves: https://github.com/lhns/fs2-compress/issues/105