### PR TITLE
Add interruption of ZipUnarchiver

### DIFF
--- a/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
+++ b/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
@@ -1,5 +1,6 @@
 package de.lhns.fs2.compress
 
+import cats.effect.kernel.Resource.ExitCase
 import cats.effect.{Async, Deferred, Resource}
 import cats.syntax.functor._
 import de.lhns.fs2.compress.ArchiveEntry.{ArchiveEntryFromUnderlying, ArchiveEntryToUnderlying}
@@ -125,9 +126,16 @@ class ZipUnarchiver[F[_]: Async] private (chunkSize: Int) extends Unarchiver[F, 
         def readEntries: Stream[F, (ArchiveEntry[Option, ZipEntry], Stream[F, Byte])] =
           Stream
             .resource(
-              Resource.make(
+              Resource.makeCase(
                 Async[F].blocking(Option(zipInputStream.getNextEntry))
-              )(_ => Async[F].blocking(zipInputStream.closeEntry()))
+              ) {
+                case (Some(entry), ExitCase.Succeeded) => Async[F].blocking(zipInputStream.closeEntry())
+                // If the resource is released for any other reason than success we don't need to close the entry
+                // as we will close the stream anyway.
+                // The `.closeEntry` method on ZipInputStream does not allow for interruption so we
+                // work around that by not calling it in the case of cancellation / error.
+                case _ => Async[F].unit
+              }
             )
             .flatMap(Stream.fromOption[F](_))
             .flatMap { entry =>


### PR DESCRIPTION
The `Resource` used for the ZipEntry in ZipUnarchiver did not allow for interruption because the `Async[F].blocking` call to the underlying `ZipInputStream.closeEntry()` is not interruptible and will block until the Entry in the ZipInputStream is read to the end.
Unfortunately signalling an interrupt to the `ZipInputStream` via `Async[F].interruptible or `Async[F].interruptibleMany` doesn't work either.

As a workaround we simply forgo closing the ZipEntry in case the resource is released for any other reason than ExitCase.Succeeded

Solves: https://github.com/lhns/fs2-compress/issues/113 though I'm not sure if this is an acceptable workaround. 

Not sure how to easily test this in an automated test 🤔 . I have tested it with the program provided in #113 🤷 