### PR TITLE
Make archivers and compressors cancelable

### DIFF
--- a/brotli4j/src/main/scala/de/lhns/fs2/compress/Brotli4J.scala
+++ b/brotli4j/src/main/scala/de/lhns/fs2/compress/Brotli4J.scala
@@ -1,23 +1,18 @@
 package de.lhns.fs2.compress
 
-import cats.effect.Async
+import cats.effect.{Async, Resource}
 import com.aayushatharva.brotli4j.Brotli4jLoader
 import com.aayushatharva.brotli4j.encoder.{BrotliOutputStream, Encoder}
 import com.aayushatharva.brotli4j.decoder.BrotliInputStream
 import fs2.{Pipe, Stream}
 import fs2.io._
 
+import java.io.OutputStream
+
 class Brotli4JCompressor[F[_]: Async] private (chunkSize: Int, params: Encoder.Parameters) extends Compressor[F] {
   override def compress: Pipe[F, Byte, Byte] = { stream =>
     Stream.exec(Async[F].blocking(Brotli4jLoader.ensureAvailability())).covaryOutput[Byte] ++
-      readOutputStream[F](chunkSize) { outputStream =>
-        stream
-          .through(
-            writeOutputStream[F](Async[F].blocking(new BrotliOutputStream(outputStream, params)))
-          )
-          .compile
-          .drain
-      }
+      stream.through(OutputStreams.throughOutputStream[F](chunkSize)(new BrotliOutputStream(_, params)))
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,11 @@ lazy val core = projectMatrix
       "org.typelevel" %%% "cats-effect" % V.catsEffect
     )
   )
-  .jvmPlatform(scalaVersions)
+  // fs2-io is JVM only here: OutputStreams wraps fs2.io.readOutputStream, which does not exist on JS.
+  .jvmPlatform(
+    scalaVersions,
+    Seq(libraryDependencies += "co.fs2" %% "fs2-io" % V.fs2)
+  )
   .jsPlatform(scalaVersions)
 
 lazy val gzip = projectMatrix

--- a/bzip2/src/main/scala/de/lhns/fs2/compress/Bzip2.scala
+++ b/bzip2/src/main/scala/de/lhns/fs2/compress/Bzip2.scala
@@ -1,31 +1,21 @@
 package de.lhns.fs2.compress
 
-import cats.effect.Async
-import fs2.Pipe
+import cats.effect.{Async, Resource}
+import fs2.{Pipe, Stream}
 import fs2.io._
 import org.apache.commons.compress.compressors.bzip2.{BZip2CompressorInputStream, BZip2CompressorOutputStream}
 
 import java.io.{BufferedInputStream, OutputStream}
 
 class Bzip2Compressor[F[_]: Async] private (blockSize: Option[Int], chunkSize: Int) extends Compressor[F] {
-  override def compress: Pipe[F, Byte, Byte] = { stream =>
-    readOutputStream[F](chunkSize) { outputStream =>
-      stream
-        .through(
-          writeOutputStream(
-            Async[F].blocking[OutputStream](
-              blockSize.fold(
-                new BZip2CompressorOutputStream(outputStream)
-              )(
-                new BZip2CompressorOutputStream(outputStream, _)
-              )
-            )
-          )
-        )
-        .compile
-        .drain
+  override def compress: Pipe[F, Byte, Byte] =
+    OutputStreams.throughOutputStream[F](chunkSize) { outputStream =>
+      blockSize.fold(
+        new BZip2CompressorOutputStream(outputStream)
+      )(
+        new BZip2CompressorOutputStream(outputStream, _)
+      )
     }
-  }
 }
 
 object Bzip2Compressor {

--- a/core/src/main/scalajvm/de/lhns/fs2/compress/OutputStreams.scala
+++ b/core/src/main/scalajvm/de/lhns/fs2/compress/OutputStreams.scala
@@ -1,0 +1,54 @@
+package de.lhns.fs2.compress
+
+import cats.effect.{Async, Resource}
+import fs2.io._
+import fs2.{Pipe, Stream}
+
+import java.io.OutputStream
+
+/** Cancelable versions of `fs2.io.readOutputStream` for codecs that are `java.io.OutputStream`s.
+  *
+  * Cancellation is the reason these exist. `Async[F].blocking` cannot be interrupted, and a `Resource` can be cancelled
+  * neither while it acquires nor while it releases. A write in one of those places therefore blocks forever once the
+  * consumer stops draining the pipe, and the cancellation never arrives.
+  */
+private[compress] object OutputStreams {
+
+  /** Like `fs2.io.readOutputStream`, except that `write` is given `wrapOutputStream` applied to the pipe, and that
+    * closing that stream can be cancelled.
+    */
+  def readWrappedOutputStream[F[_]: Async, A <: OutputStream](
+      chunkSize: Int
+  )(wrapOutputStream: OutputStream => A)(write: A => Stream[F, Nothing]): Stream[F, Byte] =
+    readOutputStream[F](chunkSize) { pipe =>
+      Resource
+        .make(Async[F].blocking(wrapOutputStream(pipe))) { outputStream =>
+          // This only runs if `write` was cancelled or failed before it closed the stream itself.
+          // The pipe is closed first, because that is what stops this from blocking: a closed pipe
+          // discards writes instead of backpressuring them, so `close()` returns even though nobody
+          // is reading, and it still releases everything it holds. fs2 closes the pipe as well, but
+          // not until this release has returned, which is too late to help here. An error raised at
+          // this point only describes the truncation we just caused, so it is ignored.
+          Async[F].void(Async[F].attempt(Async[F].blocking {
+            pipe.close()
+            outputStream.close()
+          }))
+        }
+        .use { outputStream =>
+          // The stream is closed here instead of in the release above, because a cancellation can
+          // interrupt it here. If that happens, the release closes it instead. Either way the same
+          // bytes are written.
+          (write(outputStream) ++
+            Stream.exec(Async[F].interruptible(outputStream.close()))).compile.drain
+        }
+    }
+
+  /** [[readWrappedOutputStream]] as a `Pipe`, for codecs that simply write everything they are given. */
+  def throughOutputStream[F[_]: Async](
+      chunkSize: Int
+  )(wrapOutputStream: OutputStream => OutputStream): Pipe[F, Byte, Byte] = { stream =>
+    readWrappedOutputStream[F, OutputStream](chunkSize)(wrapOutputStream) { outputStream =>
+      stream.through(writeOutputStream(Async[F].pure(outputStream), closeAfterUse = false))
+    }
+  }
+}

--- a/lz4/src/main/scala/de/lhns/fs2/compress/Lz4Compressor.scala
+++ b/lz4/src/main/scala/de/lhns/fs2/compress/Lz4Compressor.scala
@@ -1,23 +1,17 @@
 package de.lhns.fs2.compress
 
 import net.jpountz.lz4.{LZ4FrameOutputStream, LZ4FrameInputStream}
-import cats.effect.Async
-import fs2.Pipe
+import cats.effect.{Async, Resource}
+import fs2.{Pipe, Stream}
 import fs2.io._
 
 import java.io.{BufferedInputStream, OutputStream}
 
 class Lz4Compressor[F[_]: Async] private (chunkSize: Int) extends Compressor[F] {
-  override def compress: Pipe[F, Byte, Byte] = { stream =>
-    readOutputStream[F](chunkSize) { outputStream =>
-      stream
-        .through(writeOutputStream(Async[F].blocking[OutputStream] {
-          new LZ4FrameOutputStream(outputStream, LZ4FrameOutputStream.BLOCKSIZE.SIZE_256KB)
-        }))
-        .compile
-        .drain
+  override def compress: Pipe[F, Byte, Byte] =
+    OutputStreams.throughOutputStream[F](chunkSize) { outputStream =>
+      new LZ4FrameOutputStream(outputStream, LZ4FrameOutputStream.BLOCKSIZE.SIZE_256KB)
     }
-  }
 }
 
 object Lz4Compressor {

--- a/snappy/src/main/scala/de/lhns/fs2/compress/SnappyCompressor.scala
+++ b/snappy/src/main/scala/de/lhns/fs2/compress/SnappyCompressor.scala
@@ -1,7 +1,7 @@
 package de.lhns.fs2.compress
 
-import cats.effect.Async
-import fs2.Pipe
+import cats.effect.{Async, Resource}
+import fs2.{Pipe, Stream}
 import fs2.io._
 import org.xerial.snappy.{
   SnappyFramedInputStream,
@@ -14,16 +14,8 @@ import org.xerial.snappy.{
 import java.io.{BufferedInputStream, InputStream, OutputStream}
 
 class SnappyCompressor[F[_]: Async] private (chunkSize: Int, mode: SnappyCompressor.WriteMode) extends Compressor[F] {
-  override def compress: Pipe[F, Byte, Byte] = { stream =>
-    readOutputStream[F](chunkSize) { outputStream =>
-      stream
-        .through(writeOutputStream(Async[F].blocking[OutputStream] {
-          mode.fromOutputStream(outputStream)
-        }))
-        .compile
-        .drain
-    }
-  }
+  override def compress: Pipe[F, Byte, Byte] =
+    OutputStreams.throughOutputStream[F](chunkSize)(mode.fromOutputStream)
 }
 
 object SnappyCompressor {

--- a/tar/src/main/scala/de/lhns/fs2/compress/Tar.scala
+++ b/tar/src/main/scala/de/lhns/fs2/compress/Tar.scala
@@ -61,29 +61,19 @@ object Tar {
 
 class TarArchiver[F[_]: Async] private (chunkSize: Int) extends Archiver[F, Some] {
   override def archive: Pipe[F, (ArchiveEntry[Some, Any], Stream[F, Byte]), Byte] = { stream =>
-    readOutputStream[F](chunkSize) { outputStream =>
-      Resource
-        .make(Async[F].delay {
-          new TarArchiveOutputStream(outputStream)
-        })(s => Async[F].blocking(s.close()))
-        .use { tarOutputStream =>
-          stream
-            .flatMap { case (archiveEntry, stream) =>
-              def entry = archiveEntry.underlying[TarArchiveEntry]
+    OutputStreams.readWrappedOutputStream[F, TarArchiveOutputStream](chunkSize) { outputStream =>
+      new TarArchiveOutputStream(outputStream)
+    } { tarOutputStream =>
+      stream
+        .flatMap { case (archiveEntry, stream) =>
+          def entry = archiveEntry.underlying[TarArchiveEntry]
 
-              Stream
-                .resource(
-                  Resource.make(
-                    Async[F].blocking(tarOutputStream.putArchiveEntry(entry))
-                  )(_ => Async[F].blocking(tarOutputStream.closeArchiveEntry()))
-                )
-                .flatMap(_ =>
-                  stream
-                    .through(writeOutputStream(Async[F].pure[OutputStream](tarOutputStream), closeAfterUse = false))
-                )
-            }
-            .compile
-            .drain
+          // These writes happen in the stream rather than in a Resource so that they can be
+          // cancelled. See OutputStreams.
+          Stream.exec(Async[F].interruptible(tarOutputStream.putArchiveEntry(entry))) ++
+            stream
+              .through(writeOutputStream(Async[F].pure[OutputStream](tarOutputStream), closeAfterUse = false)) ++
+            Stream.exec(Async[F].interruptible(tarOutputStream.closeArchiveEntry()))
         }
     }
   }

--- a/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
+++ b/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
@@ -55,32 +55,22 @@ object Zip {
 
 class ZipArchiver[F[_]: Async, Size[A] <: Option[A]] private (method: Int, chunkSize: Int) extends Archiver[F, Size] {
   override def archive: Pipe[F, (ArchiveEntry[Size, Any], Stream[F, Byte]), Byte] = { stream =>
-    readOutputStream[F](chunkSize) { outputStream =>
-      Resource
-        .make(Async[F].delay {
-          val zipOutputStream = new ZipOutputStream(outputStream)
-          zipOutputStream.setMethod(method)
-          zipOutputStream
-        })(zipOutputStream => Async[F].blocking(zipOutputStream.close()))
-        .use { zipOutputStream =>
-          stream
-            .through(checkUncompressedSize)
-            .flatMap { case (archiveEntry, stream) =>
-              def entry = archiveEntry.underlying[ZipEntry]
+    OutputStreams.readWrappedOutputStream[F, ZipOutputStream](chunkSize) { outputStream =>
+      val zipOutputStream = new ZipOutputStream(outputStream)
+      zipOutputStream.setMethod(method)
+      zipOutputStream
+    } { zipOutputStream =>
+      stream
+        .through(checkUncompressedSize)
+        .flatMap { case (archiveEntry, stream) =>
+          def entry = archiveEntry.underlying[ZipEntry]
 
-              Stream
-                .resource(
-                  Resource.make(
-                    Async[F].blocking(zipOutputStream.putNextEntry(entry))
-                  )(_ => Async[F].blocking(zipOutputStream.closeEntry()))
-                )
-                .flatMap(_ =>
-                  stream
-                    .through(writeOutputStream(Async[F].pure[OutputStream](zipOutputStream), closeAfterUse = false))
-                )
-            }
-            .compile
-            .drain
+          // These writes happen in the stream rather than in a Resource so that they can be
+          // cancelled. See OutputStreams.
+          Stream.exec(Async[F].interruptible(zipOutputStream.putNextEntry(entry))) ++
+            stream
+              .through(writeOutputStream(Async[F].pure[OutputStream](zipOutputStream), closeAfterUse = false)) ++
+            Stream.exec(Async[F].interruptible(zipOutputStream.closeEntry()))
         }
     }
   }
@@ -124,11 +114,10 @@ class ZipUnarchiver[F[_]: Async] private (chunkSize: Int) extends Unarchiver[F, 
       .flatMap { zipInputStream =>
         def readEntries: Stream[F, (ArchiveEntry[Option, ZipEntry], Stream[F, Byte])] =
           Stream
-            .resource(
-              Resource.make(
-                Async[F].blocking(Option(zipInputStream.getNextEntry))
-              )(_ => Async[F].blocking(zipInputStream.closeEntry()))
-            )
+            // There is no closeEntry() finalizer here. getNextEntry() already calls closeEntry()
+            // before it advances, so it was redundant, and because a finalizer cannot be
+            // interrupted it drained the whole remaining entry whenever the stream was cancelled.
+            .eval(Async[F].blocking(Option(zipInputStream.getNextEntry)))
             .flatMap(Stream.fromOption[F](_))
             .flatMap { entry =>
               val archiveEntry = ArchiveEntry.fromUnderlying(entry)

--- a/zip4j/src/main/scala/de/lhns/fs2/compress/Zip4J.scala
+++ b/zip4j/src/main/scala/de/lhns/fs2/compress/Zip4J.scala
@@ -66,31 +66,23 @@ object Zip4J {
 
 class Zip4JArchiver[F[_]: Async] private (password: => Option[String], chunkSize: Int) extends Archiver[F, Some] {
   def archive: Pipe[F, (ArchiveEntry[Some, Any], Stream[F, Byte]), Byte] = { stream =>
-    readOutputStream[F](chunkSize) { outputStream =>
-      Resource
-        .make(Async[F].delay {
-          val zipOutputStream = new ZipOutputStream(outputStream, password.map(_.toCharArray).orNull)
-          zipOutputStream
-        })(zipOutputStream => Async[F].blocking(zipOutputStream.close()))
-        .use { zipOutputStream =>
-          stream
-            .through(checkUncompressedSize)
-            .flatMap { case (archiveEntry, stream) =>
-              def entry = archiveEntry.underlying[ZipParameters]
+    OutputStreams.readWrappedOutputStream[F, ZipOutputStream](chunkSize) { outputStream =>
+      new ZipOutputStream(outputStream, password.map(_.toCharArray).orNull)
+    } { zipOutputStream =>
+      stream
+        .through(checkUncompressedSize)
+        .flatMap { case (archiveEntry, stream) =>
+          def entry = archiveEntry.underlying[ZipParameters]
 
-              Stream
-                .resource(
-                  Resource.make(
-                    Async[F].blocking(zipOutputStream.putNextEntry(entry))
-                  )(_ => Async[F].blocking(zipOutputStream.closeEntry()))
-                )
-                .flatMap(_ =>
-                  stream
-                    .through(writeOutputStream(Async[F].pure[OutputStream](zipOutputStream), closeAfterUse = false))
-                )
-            }
-            .compile
-            .drain
+          // These writes happen in the stream rather than in a Resource so that they can be
+          // cancelled. See OutputStreams.
+          Stream.exec(Async[F].interruptible(zipOutputStream.putNextEntry(entry))) ++
+            stream
+              .through(writeOutputStream(Async[F].pure[OutputStream](zipOutputStream), closeAfterUse = false)) ++
+            Stream.exec(Async[F].interruptible {
+              zipOutputStream.closeEntry()
+              ()
+            })
         }
     }
   }
@@ -121,13 +113,9 @@ class Zip4JUnarchiver[F[_]: Async] private (chunkSize: Int) extends Unarchiver[F
       .flatMap { zipInputStream =>
         def readEntries: Stream[F, (ArchiveEntry[Option, LocalFileHeader], Stream[F, Byte])] =
           Stream
-            .resource(
-              Resource.make(
-                Async[F].blocking(Option(zipInputStream.getNextEntry))
-              )(_ =>
-                Async[F].unit // .blocking(zipInputStream.closeEntry())
-              )
-            )
+            // There is no closeEntry() finalizer here. getNextEntry() already reads to the end of
+            // the previous entry, and a drain that cannot be interrupted would block cancellation.
+            .eval(Async[F].blocking(Option(zipInputStream.getNextEntry)))
             .flatMap(Stream.fromOption[F](_))
             .flatMap { entry =>
               val archiveEntry = ArchiveEntry.fromUnderlying(entry)

--- a/zstd/src/main/scala/de/lhns/fs2/compress/Zstd.scala
+++ b/zstd/src/main/scala/de/lhns/fs2/compress/Zstd.scala
@@ -1,27 +1,21 @@
 package de.lhns.fs2.compress
 
-import cats.effect.Async
+import cats.effect.{Async, Resource}
 import com.github.luben.zstd.{ZstdInputStream, ZstdOutputStream}
-import fs2.Pipe
+import fs2.{Pipe, Stream}
 import fs2.io._
 
 import java.io.{BufferedInputStream, OutputStream}
 
 class ZstdCompressor[F[_]: Async] private (level: Option[Int], workers: Option[Int], chunkSize: Int)
     extends Compressor[F] {
-  override def compress: Pipe[F, Byte, Byte] = { stream =>
-    readOutputStream[F](chunkSize) { outputStream =>
-      stream
-        .through(writeOutputStream(Async[F].blocking[OutputStream] {
-          val zstdOutputStream = new ZstdOutputStream(outputStream)
-          level.foreach(zstdOutputStream.setLevel)
-          workers.foreach(zstdOutputStream.setWorkers)
-          zstdOutputStream
-        }))
-        .compile
-        .drain
+  override def compress: Pipe[F, Byte, Byte] =
+    OutputStreams.throughOutputStream[F](chunkSize) { outputStream =>
+      val zstdOutputStream = new ZstdOutputStream(outputStream)
+      level.foreach(zstdOutputStream.setLevel)
+      workers.foreach(zstdOutputStream.setWorkers)
+      zstdOutputStream
     }
-  }
 }
 
 object ZstdCompressor {


### PR DESCRIPTION
Re-targets the fix at `main`. #339 was opened against the `interruption-tests` branch so that `main` would never be red between the two merges, but #335 was squash-merged into `main` first and #339 then merged into `interruption-tests`, so the fix never reached `main`. **`main` is red right now**: it has the cancellation tests without the fix that makes them pass.

This is the same commit as #339, cherry-picked onto current `main`. It applied cleanly, and the full suite is green locally (21 suites, all Scala versions).

---

The root cause is narrower than "closeEntry blocks". `Async[F].blocking` cannot be interrupted, and **both halves of a `Resource` are uncancelable regions**, so any write performed in one of them blocks forever once the consumer stops draining the `fs2.io.readOutputStream` pipe — and the cancellation can then never be delivered.

Thread dumps put the blocked frame in three genuinely different places, which is why a single-site fix was never going to be enough:

| Where it blocks | Frame |
|---|---|
| Entry **finalizer**, draining the rest of the entry from a still-live upstream | `ZipInputStream.closeEntry()` |
| Resource **acquire**, writing a 512-byte header into a full pipe | `TarArchiveOutputStream.putArchiveEntry()` |
| Outer **finalizer**, flushing the final block into a pipe nobody reads | `BZip2CompressorOutputStream.close()` |

## The fix: stop writing inside uncancelable regions

- **The entry header/trailer and the close of the underlying stream move out of `Resource` and into the stream**, as `Async[F].interruptible`. There an interrupt actually lands; on the happy path the byte order is unchanged.
- **The `Resource` release becomes a uniform safety net** for the paths where the stream did not get that far. It closes the fs2 `OutputStream` **first**, which is what makes it non-blocking: writes to a closed `PipedStreamBuffer` are no-ops rather than errors, so `close()` runs to completion and still releases what it owns — `Deflater.end()`, `ZSTD_freeCStream`, brotli4j's `Encoder`. Only trailer bytes are dropped, which is correct for output nobody is reading.
- **`ZipUnarchiver` drops its per-entry `closeEntry()` finalizer outright.** `ZipInputStream.getNextEntry()` calls `closeEntry()` itself before advancing (verified in the bytecode), so it was redundant on the happy path and pure liability on every other one. This makes it match `TarUnarchiver`, which never had one, and `Zip4JUnarchiver`, where it was commented out.

Closing the pipe in the release is safe on the success path, and this was verified rather than assumed: fs2's own `readOutputStream` already closes it in a `guaranteeCase` immediately after the body, and `PipedStreamBuffer`'s reader checks for buffered bytes *before* it checks the closed flag, so it drains what is left and only then reports EOF. Removing that one line locally brought back 10 failures, so it is load-bearing rather than redundant.

The repeated plumbing is now `OutputStreams.readWrappedOutputStream` and `OutputStreams.throughOutputStream`, which is why the diff removes more lines than it adds. That puts `fs2-io` on `core`, but only on the JVM row and only because `readOutputStream` lives there — it does not exist on JS, so the helper sits in `core/src/main/scalajvm` and the JS artifact is unchanged.

## Results

Every one of the 16 tests that fail on `main` passes, and every pre-existing round-trip suite still passes unchanged, which is what pins the guarantee that the success path is byte-for-byte identical.

## Known limitations, not addressed here

- **Cancellation latency is bounded, not zero.** `fs2.io.readInputStream` reads inside `F.blocking`, so a cancellation still waits for the read that is in flight. Fixing that needs fs2's `readInputStreamCancelable`, which is `private[io]`.
- **The `Deferred` handshake in the unarchivers** can still deadlock when a consumer abandons an entry stream. It is a cancelable park in the pull loop rather than a finalizer, so it is a different bug and deserves its own PR.
- **`ZipArchiver.makeStored` is broken independently** (it never sets CRC or compressed size), as noted in #335.
