### PR TITLE
Write down the decisions behind the library in docs/adr

### DIFF
--- a/docs/adr/0001-bridge-java-io-streams-into-fs2.md
+++ b/docs/adr/0001-bridge-java-io-streams-into-fs2.md
@@ -1,0 +1,58 @@
+# 1. Bridge java.io codec streams into fs2
+
+Date: 2023-01-11
+
+## Status
+
+Accepted
+
+## Context
+
+Almost every compression codec on the JVM ships as a pair of `java.io` stream decorators:
+`ZipOutputStream`, `BZip2CompressorOutputStream`, `ZstdOutputStream`, `LZ4FrameOutputStream`
+and so on. They are blocking, they are stateful, and they expect to be handed a stream to
+wrap. fs2 works the other way around: pull-based, effectful, non-blocking by default.
+
+Reimplementing each codec natively in fs2 would mean porting compression formats, which is
+neither realistic nor desirable for a library whose value is the fs2 integration itself.
+
+## Decision
+
+Wrap the existing `java.io` implementations rather than reimplement them, using fs2's own
+bridges. Compression runs the codec's `OutputStream` inside `fs2.io.readOutputStream` and
+feeds it with `writeOutputStream`; decompression turns the byte stream into an `InputStream`
+with `fs2.io.toInputStream`, wraps it in the codec's `InputStream`, and reads it back with
+`readInputStream`. Every blocking call goes through `Async[F].blocking`.
+
+This shape is present in the first code commit (`9ed3d84`) and every codec added since has
+followed it — see ADR 0014.
+
+The same commit fixes a default chunk size for the whole library:
+
+```scala
+object Defaults {
+  val defaultChunkSize: Int = 1024 * 64
+}
+```
+
+64 KiB is deliberately far larger than fs2's own 4 KiB default. These paths cross into JNI
+and syscalls per call, so the per-call overhead dominates and larger buffers pay off. It is
+the default argument of essentially every `make` in the repo, and every instance can
+override it.
+
+## Consequences
+
+- New codecs are cheap to add: the wrapping is mechanical and identical each time.
+- The library inherits the semantics of the underlying streams, including the ones that
+  hurt. Everything that ADR 0018 and ADR 0020 had to fix follows from these being blocking,
+  uninterruptible, single-pass streams.
+- Anything reachable through `java.io` is JVM-only, which is why ADR 0003 ends up with only
+  two cross-built modules.
+- `chunkSize` is not just a buffer size: `fs2.io.readOutputStream` allocates a
+  `PipedStreamBuffer` of exactly that capacity, so it is also the amount of slack between
+  producer and consumer. The cancellation tests exploit this by shrinking it to 64 bytes.
+
+## References
+
+- `9ed3d84` "added files" (2023-01-11) — the initial implementation and `Defaults.scala`
+- `core/src/main/scala/de/lhns/fs2/compress/Defaults.scala`

--- a/docs/adr/0002-one-module-per-codec.md
+++ b/docs/adr/0002-one-module-per-codec.md
@@ -1,0 +1,70 @@
+# 2. Give each codec its own module
+
+Date: 2023-01-11
+
+## Status
+
+Accepted
+
+## Context
+
+The library began as a single `core` artifact containing gzip, zip, zstd and bzip2 together,
+which meant one dependency list for all of them:
+
+```scala
+libraryDependencies ++= Seq(
+  "co.fs2" %% "fs2-io" % V.fs2,
+  "com.github.luben" % "zstd-jni" % V.zstdJni,
+  "org.apache.commons" % "commons-compress" % V.commonsCompress,
+  "org.typelevel" %% "cats-effect" % V.catsEffect
+)
+```
+
+Anyone who wanted gzip also got zstd-jni, a multi-megabyte jar carrying native binaries for
+every supported platform, plus commons-compress.
+
+The problem surfaced within the hour. Commit `5a7c1ac`, twenty-four minutes after the code
+landed, demoted zstd-jni to test scope:
+
+```diff
+-      "com.github.luben" % "zstd-jni" % V.zstdJni,
++      "com.github.luben" % "zstd-jni" % V.zstdJni % Test,
+```
+
+That shrank the published artifact and broke it at the same time: `ZstdCompressor` was still
+in the jar, but no longer compilable by anyone downstream.
+
+## Decision
+
+Split into `core` plus one module per codec, using sbt-projectmatrix. `core` keeps only
+fs2-core and cats-effect. Each codec module depends on `core` and owns its native
+dependency, and is published as its own artifact (`fs2-compress-gzip`, `fs2-compress-zstd`,
+and so on).
+
+The split commit puts zstd-jni straight back into compile scope — undoing the workaround is
+precisely what it was for.
+
+## Considered options
+
+- **One artifact.** What was there. Rejected: it forces every dependency on every user.
+- **One artifact with optional dependencies at test scope.** Tried for twenty-four minutes
+  in `5a7c1ac`. Rejected: it does not actually make the code usable, it just hides it.
+- **One artifact per codec.** Chosen.
+
+## Consequences
+
+- Users depend on exactly the codecs they use. This is the reason the README lists ten
+  separate coordinates rather than one.
+- Adding a codec means touching `build.sbt` in three places (version, aggregate, module),
+  which ADR 0014 turns into a repeatable shape.
+- Modules are wired as `core % "compile->compile;test->test"` so they can reuse the shared
+  test scaffolding in `core`. That wiring is what later lets the abstract cancellation and
+  unarchive suites live in `core` and be subclassed per codec.
+- Eleven modules times three Scala versions makes for a large build matrix, which is why CI
+  runs with a raised heap.
+
+## References
+
+- `9ed3d84` "added files", `5a7c1ac` "change zstd-jni scope to test" (2023-01-11)
+- `1099bb0` "modules" (2023-01-11), merged as PR #1
+- `94c0360` "updated build.sbt" — adds the `test->test` wiring

--- a/docs/adr/0003-cross-build-to-scala-js-where-possible.md
+++ b/docs/adr/0003-cross-build-to-scala-js-where-possible.md
@@ -1,0 +1,45 @@
+# 3. Cross-build to Scala.js only where the codec allows it
+
+Date: 2023-01-11
+
+## Status
+
+Accepted
+
+## Context
+
+fs2 itself runs on both the JVM and Scala.js, so a library built on it is expected to offer
+the same. The codecs, however, are wrapped `java.io` implementations (ADR 0001), and most of
+them exist only as JVM jars: zstd-jni is JNI, commons-compress and `org.brotli:dec` are
+Java-only, and `java.util.zip` has no Scala.js equivalent.
+
+## Decision
+
+Cross-build each module only where its implementation permits, rather than holding the whole
+library to the lowest common denominator.
+
+In practice that leaves `core` and `gzip` cross-built, and everything else JVM-only. Gzip
+survives because it does not wrap a `java.io` stream at all — it delegates to fs2's own
+`Compression`, which is backed by `java.util.zip` on the JVM and Node's zlib on Scala.js. See
+ADR 0006 for how that constraint settled.
+
+`zip` was briefly cross-built and dropped in `94c0360`, once `java.util.zip` and
+`java.nio.file.attribute.FileTime` made it impossible.
+
+## Consequences
+
+- Scala.js users get gzip and the core abstractions, and nothing else. That is an honest
+  reflection of what is portable.
+- Anything placed in `core` must link on both platforms. This is a real constraint, not a
+  formality: it is why `OutputStreams` (ADR 0019) lives in `core/src/main/scalajvm` with a
+  JVM-only `fs2-io` dependency, and why the shared test suites avoid `java.io` entirely.
+- JS tests need `ModuleKind.CommonJSModule` so the linked bundle can require Node's zlib.
+- The build matrix is three Scala versions across two platforms for two modules, and three
+  Scala versions for the other nine.
+
+## References
+
+- `1099bb0` "modules" — introduces sbt-scalajs and the initial platform split
+- `94c0360` "updated build.sbt" — drops JS from `zip`
+- `ba2a8c9` "fixed gzip js compile" — keeps `gzip` portable via fs2's `Compression`
+- `9523ca0` "js test modules" — CommonJS module kind for tests

--- a/docs/adr/0004-four-traits-and-single-file-adapters.md
+++ b/docs/adr/0004-four-traits-and-single-file-adapters.md
@@ -1,0 +1,61 @@
+# 4. Model the four operations as traits, with single-file adapters
+
+Date: 2023-01-13
+
+## Status
+
+Accepted
+
+## Context
+
+The library covers two different things that are easy to conflate. Compression turns bytes
+into fewer bytes — gzip, zstd, bzip2. Archiving collects named entries into one container —
+zip, tar. Some formats are one, some are the other, and `.tar.gz` is both composed.
+
+A user also frequently wants the degenerate case: put a single file into a zip, or read the
+one file back out, without dealing with entries at all.
+
+## Decision
+
+Four traits, each a single `Pipe`:
+
+```scala
+trait Compressor[F[_]]   { def compress:   Pipe[F, Byte, Byte] }
+trait Decompressor[F[_]] { def decompress: Pipe[F, Byte, Byte] }
+
+trait Archiver[F[_], Size[A] <: Option[A]] {
+  def archive: Pipe[F, (ArchiveEntry[Size, Any], Stream[F, Byte]), Byte]
+}
+trait Unarchiver[F[_], Size[A] <: Option[A], Underlying] {
+  def unarchive: Pipe[F, Byte, (ArchiveEntry[Size, Underlying], Stream[F, Byte])]
+}
+```
+
+Because each is just a pipe, composition is ordinary fs2: `.through(archiver.archive)
+.through(compressor.compress)` is how you write a `.tar.gz`, and the library needs no
+concept of a combined format.
+
+For the single-file case, `ArchiveSingleFileCompressor` and `ArchiveSingleFileDecompressor`
+adapt an `Archiver`/`Unarchiver` down to the `Compressor`/`Decompressor` interface. That is
+what makes a one-file zip usable anywhere a plain compressor is expected.
+
+`Compressor` and `Decompressor` date from the first commit and are unchanged since.
+`Archiver`, `Unarchiver` and the single-file adapters arrived with tar support.
+
+## Consequences
+
+- The entry stream in `Archiver`/`Unarchiver` is nested inside the outer stream. That nesting
+  is the source of the hardest problems in this library: what happens when the consumer does
+  not read an entry (ADR 0020), and when it cancels mid-entry (ADR 0018).
+- `Archiver` carries a `Size` parameter that `Compressor` does not need, because archive
+  formats may require a declared size — see ADR 0008 and ADR 0009.
+- `ArchiveSingleFileDecompressor` ends in `.head`, taking the first entry and ignoring the
+  rest. This turns out to matter for cancellation semantics, since early termination is
+  reported differently from a real cancellation.
+
+## References
+
+- `9ed3d84` (2023-01-11) — `Compressor`, `Decompressor`, and `ZipSingleFile`
+- `5198a98` "tar and archivers" (2023-01-13) — `Archiver`, `Unarchiver`, and the generalised
+  `ArchiveSingleFile`
+- `core/src/main/scala/de/lhns/fs2/compress/{Compressor,Decompressor,Archiver,Unarchiver,ArchiveSingleFile}.scala`

--- a/docs/adr/0005-apply-summons-make-constructs.md
+++ b/docs/adr/0005-apply-summons-make-constructs.md
@@ -1,0 +1,54 @@
+# 5. `apply` summons, `make` constructs, constructors are private
+
+Date: 2023-09-08
+
+## Status
+
+Accepted
+
+## Context
+
+Originally `apply` was the constructor, so a caller wrote `GzipCompressor[IO]()` and passed
+the result around explicitly.
+
+But the four traits of ADR 0004 are capabilities: a function that compresses something wants
+to say "give me any `Compressor[F]`", not "give me this specific gzip instance configured
+this way". That is the standard implicit-summoner idiom in the Typelevel ecosystem, and it
+needs `apply` free to mean "summon the instance in scope".
+
+## Decision
+
+In every companion object, `apply` summons and `make` constructs:
+
+```scala
+object ZstdCompressor {
+  def apply[F[_]](implicit instance: ZstdCompressor[F]): ZstdCompressor[F] = instance
+
+  def make[F[_]: Async](level: Option[Int] = None, ...): ZstdCompressor[F] =
+    new ZstdCompressor(level, ...)
+}
+```
+
+Call sites became `implicit val c = GzipCompressor.make()` followed by
+`GzipCompressor[IO].compress`. The author treated this as the API-defining change and
+released it as 1.0.0.
+
+Seven months later the class constructors were made `private`, closing the remaining way to
+bypass `make`.
+
+## Consequences
+
+- The constructor signature is an implementation detail. That freedom is exercised directly
+  in ADR 0012, where `ZipArchiver.make` is deprecated and replaced by two named factories
+  without touching the class.
+- Every module follows the convention, which makes the codebase very uniform and gives new
+  codec contributions an obvious shape to copy (ADR 0014).
+- Instances must be brought into implicit scope by the caller, which is more ceremony for
+  someone who just wants to compress one stream. The single-file adapters and the explicit
+  `make(...)` form remain available for that.
+
+## References
+
+- `e7fcb65` "type classes" (2023-09-08) — introduces `make` and the summoner; released as
+  1.0.0
+- `1ba242e` "make constructors private" (2024-04-12) — the second stage

--- a/docs/adr/0006-require-compression-instance-for-gzip.md
+++ b/docs/adr/0006-require-compression-instance-for-gzip.md
@@ -1,0 +1,65 @@
+# 6. Require `Compression[F]` for gzip rather than `LiftIO`
+
+Date: 2023-09-08
+
+## Status
+
+Accepted
+
+## Context
+
+Gzip is the one codec implemented by delegating to fs2's `Compression` rather than wrapping a
+`java.io` stream, which is what keeps it cross-built (ADR 0003).
+
+fs2 3.7.0 reworked how `Compression` instances are obtained, and the first adaptation pinned
+the JVM one directly:
+
+```scala
+private val compression: Compression[F] = Compression.forSync
+```
+
+That compiles on the JVM and breaks Scala.js, which has no `forSync`.
+
+The next attempt, twelve minutes later, went back to `fs2.io.compression._` and satisfied its
+new requirement by demanding `LiftIO` from the caller:
+
+```scala
+class GzipCompressor[F[_]: Async: LiftIO](...)
+```
+
+It worked, but it leaked an implementation detail into every user's constraint list: fs2's
+Node-backed instance happens to be derived via `LiftIO`, and nothing about gzip compression
+should require the caller to know that.
+
+## Decision
+
+Ask for the thing actually needed. `GzipCompressor` and `GzipDecompressor` require
+`Compression[F]`:
+
+```scala
+class GzipCompressor[F[_]: Async: Compression] private (...)
+```
+
+The caller brings an instance with `import fs2.io.compression._` on either platform, and the
+library stays platform-neutral without naming a platform-specific mechanism.
+
+## Considered options
+
+- **Pin `Compression.forSync`.** Simplest, and breaks Scala.js. Rejected.
+- **Require `LiftIO`.** Works on both platforms, but constrains callers by an unrelated
+  capability. Rejected after roughly four months in place.
+- **Require `Compression[F]`.** Chosen.
+
+## Consequences
+
+- Gzip's constraint list says what it means, and gzip remains the only cross-built codec.
+- `LiftIO` appears nowhere in the library today.
+- Callers must import an instance. This is one extra import for gzip that the wrapped codecs
+  do not need, since those only require `Async`.
+
+## References
+
+- `0e3d17a` "fs2 3.7.0" (2023-05-17) — pins `forSync`
+- `cc1d3b2` "LiftIO" (2023-05-17) — the interim fix
+- `e7fcb65` "type classes" (2023-09-08) — replaces `LiftIO` with `Compression`
+- `gzip/src/main/scala/de/lhns/fs2/compress/Gzip.scala`

--- a/docs/adr/0007-second-zip-implementation-for-encryption.md
+++ b/docs/adr/0007-second-zip-implementation-for-encryption.md
@@ -1,0 +1,48 @@
+# 7. Ship a second zip implementation for encryption
+
+Date: 2023-11-07
+
+## Status
+
+Accepted
+
+## Context
+
+The `zip` module wraps `java.util.zip`, which is in the JDK, has no extra dependencies, and
+cannot read or write encrypted archives. Password-protected zips are common enough that
+"this library cannot open that file" is a real gap, and the JDK offers nothing to close it.
+
+## Decision
+
+Add a separate `zip4j` module wrapping the zip4j library, and keep the JDK-based `zip`
+module alongside it. Users who need encryption take the extra dependency; users who do not,
+do not.
+
+The archiver takes the password by name, so a secret need not be held in memory for the
+lifetime of the instance:
+
+```scala
+def make[F[_]: Async](password: => Option[String] = None, chunkSize: Int = Defaults.defaultChunkSize)
+```
+
+The module sat in a rough state for five months — the first version had a literal
+`"password"` hardcoded and a `method: Int` parameter whose effect was commented out — and was
+finished in `849bec8`, which also moved it onto the `ArchiveEntry` encoding of ADR 0011.
+
+## Consequences
+
+- Two modules read and write the same format, and they are **not** interchangeable.
+  `Zip4JArchiver` is `Archiver[F, Some]` and always needs a declared entry size, while the
+  JDK `ZipArchiver` is parameterised and does not (ADR 0009). Switching between them is a
+  type-level change, not a drop-in swap.
+- zip4j needs two different native types for one format — `ZipParameters` when writing,
+  `LocalFileHeader` when reading. The old single-`Entry` `Archiver` could not express that,
+  which is part of what motivated ADR 0011.
+- Both must be maintained. Every change to the shared entry machinery lands in three
+  archivers rather than two.
+
+## References
+
+- Issue #106; `781a64c` "zip4j module" (2023-11-07)
+- `849bec8` "fixed zip4j Archiver" (2024-04-12) — real password parameter, new entry encoding
+- `zip4j/src/main/scala/de/lhns/fs2/compress/Zip4J.scala`

--- a/docs/adr/0008-declare-entry-size-instead-of-buffering.md
+++ b/docs/adr/0008-declare-entry-size-instead-of-buffering.md
@@ -1,0 +1,57 @@
+# 8. Stream archive entries by declaring the size up front
+
+Date: 2024-04-10
+
+## Status
+
+Accepted
+
+## Context
+
+Tar writes a header before each entry's payload, and that header contains the uncompressed
+size. Zip's STORED method likewise needs the size and CRC in the local header. The size must
+therefore be known before the first byte of payload is written.
+
+The original archivers obtained it the only way they could without asking: by buffering the
+whole entry with `chunkAll` and measuring it. Issue #77 reported the consequence:
+
+> The use of `chunkAll` in `TarArchiver#archive` and in `ZipArchiver#archive` causes all the
+> bytes for each entry to be read into memory, which can lead to out-of-memory errors for
+> large entries.
+
+So the library was not really streaming archives at all — it was assembling them in memory,
+one entry at a time. For a streaming library that is a defect, not a trade-off.
+
+## Decision
+
+Stop deriving the size and require the caller to declare it, then encode in the type whether
+a given archiver requires it, using a higher-kinded parameter bounded by `Option`:
+
+```scala
+trait Archiver[F[_], Size[A] <: Option[A]] {
+  def archive: Pipe[F, (ArchiveEntry[Size], Stream[F, Byte]), Byte]
+}
+```
+
+Instantiated at `Some`, the size is mandatory and the compiler enforces it, because
+`Some[Long]` cannot be `None`. Instantiated at `Option`, it is optional. `chunkAll`
+disappears and entries stream through.
+
+`ArchiveSingleFileCompressor.forName` gained two overloads so the distinction is visible at
+the call site — one that takes a size, one that does not.
+
+## Consequences
+
+- Entries of any size can be archived in constant memory.
+- The caller has to know the size in advance. For a file on disk that is a `stat`; for a
+  computed stream it may mean restructuring, and that is the real cost of this decision.
+- A declared size is now the only source of truth, and nothing checks it — which is exactly
+  the gap ADR 0010 closes.
+- The higher-kinded `Size` parameter appears in every archiver signature from here on. Six
+  months later it needed refining: see ADR 0009.
+
+## References
+
+- Issue #77 "Tar and zip archivers read entries fully into memory"
+- `b5d234f` "require size for an archive entry" (2024-04-10), PR #104
+- `core/src/main/scala/de/lhns/fs2/compress/{ArchiveEntry,Archiver,ArchiveSingleFile}.scala`

--- a/docs/adr/0009-archiver-type-states-whether-size-is-required.md
+++ b/docs/adr/0009-archiver-type-states-whether-size-is-required.md
@@ -1,0 +1,68 @@
+# 9. Let the archiver's type say whether a size is required
+
+Date: 2024-10-10
+
+## Status
+
+Accepted. Refines ADR 0008.
+
+## Context
+
+ADR 0008 made the entry size explicit, and `ZipArchiver` was declared `Archiver[F, Some]` —
+a size is always required — because the archiver could be configured to use the STORED
+method, which needs one.
+
+But zip's default DEFLATED method does not need the size up front. Requiring it anyway made
+zip unusable for the case it was best suited to, as the contributor put it:
+
+> Requiring Some for the Size of ZipArchive makes it impossible to work with if you have
+> streams of entries where you don't know the size up front (without reading all that data
+> into memory).
+
+which is the very problem ADR 0008 set out to solve.
+
+## Decision
+
+Let each archiver's type state its own requirement, by parameterising `ZipArchiver` over
+`Size` rather than fixing it:
+
+```scala
+class ZipArchiver[F[_]: Async, Size[A] <: Option[A]] private (method: Int, chunkSize: Int)
+    extends Archiver[F, Size]
+```
+
+and exposing the two valid combinations as named factories, so the compression method and the
+size requirement cannot be chosen independently:
+
+- `makeDeflated` → `ZipArchiver[F, Option]`
+- `makeStored`   → `ZipArchiver[F, Some]`
+
+Today `TarArchiver` and `Zip4JArchiver` are `Archiver[F, Some]`, `ZipArchiver` is whichever
+the factory says, and every unarchiver is `Unarchiver[F, Option, _]` — reading back, a size
+may legitimately be absent.
+
+## Considered options
+
+- **Keep `Archiver[F, Some]` everywhere.** Rejected: forces callers back to buffering.
+- **Make `ZipArchiver` an `Archiver[F, Option]` and let `Size` be contravariant**, so an
+  `Archiver[F, Option]` is usable where `Archiver[F, Some]` is expected. This was actually
+  committed, then reverted a day later: it makes the relationship implicit and still leaves
+  one archiver claiming a single fixed answer.
+- **Parameterise the archiver and name the factories.** Chosen: the requirement travels with
+  the instance, and the invalid combinations cannot be constructed.
+
+## Consequences
+
+- `makeDeflated`/`makeStored` express what a bare `method: Int` could not, which is why the
+  old factory is deprecated in ADR 0012.
+- Signatures involving archivers now carry a higher-kinded parameter, which is a real
+  readability cost for a library whose main types are otherwise simple pipes.
+- Choosing between the two zip modules is a type-level decision (ADR 0007).
+
+## References
+
+- `8d58cf7` "Make ZipArchiver work with Option instead of Some" (2024-10-09), PR #148 — the
+  contravariance attempt
+- `944cc1c` "Add Size parameter to ZipArchive" (2024-10-10) — reverts the variance,
+  parameterises the class, adds the named factories
+- `zip/src/main/scala/de/lhns/fs2/compress/Zip.scala`

--- a/docs/adr/0010-verify-the-declared-entry-size.md
+++ b/docs/adr/0010-verify-the-declared-entry-size.md
@@ -1,0 +1,61 @@
+# 10. Verify the declared entry size while archiving
+
+Date: 2024-04-12
+
+## Status
+
+Accepted
+
+## Context
+
+After ADR 0008 the caller declares each entry's size and the archiver writes it into the
+header before the payload. Nothing checked that the payload then matched.
+
+For tar this was already handled: commons-compress validates against the declared header
+size and fails. For zip in DEFLATED mode it was not. `java.util.zip.ZipOutputStream` happily
+writes a structurally valid archive whose central directory records a size that never
+occurred — silent corruption, discovered by whoever tries to read the file later, possibly
+in a different program on a different day.
+
+## Decision
+
+Count the bytes actually streamed and fail if they do not match what was declared. A shared
+pipe in the `Archiver` companion does it:
+
+```scala
+def checkUncompressedSize[F[_]: Async, Size[A] <: Option[A]]: Pipe[F, ...] =
+  _.map { case (entry, bytes) =>
+    val newBytes = (entry.uncompressedSize: Option[Long]) match {
+      case None => bytes
+      case Some(expectedSize) =>
+        Stream.eval(Ref[F].of(0L)).flatMap { sizeRef =>
+          bytes.chunks.evalTap(chunk => sizeRef.update(_ + chunk.size)).unchunks ++
+            Stream.exec(sizeRef.get.map { size =>
+              if (size != expectedSize) throw new IllegalStateException(...)
+            })
+        }
+    }
+    (entry, newBytes)
+  }
+```
+
+`ZipArchiver` and `Zip4JArchiver` run their entry stream through it. `TarArchiver` does not,
+because commons-compress already does the equivalent.
+
+It is a no-op when no size was declared, so the `Size = Option` path costs nothing.
+
+## Consequences
+
+- A mismatch fails loudly at the point of archiving, rather than producing a file that is
+  wrong somewhere else later.
+- The check is per chunk and adds a `Ref` update to every chunk written. Negligible against
+  the compression itself.
+- This established the pattern the library reaches for whenever a caller can be wrong in a
+  way that would otherwise corrupt output silently: count, compare, raise
+  `IllegalStateException`. ADR 0020 follows the same shape on the reading side.
+
+## References
+
+- `2edaff6` "added test for wrong body size" (2024-04-12) — the failing tests first
+- `62a6fe1` "check entry size in ZipArchiver" (2024-04-12)
+- `core/src/main/scala/de/lhns/fs2/compress/Archiver.scala`

--- a/docs/adr/0011-carry-the-native-entry-behind-a-type-class.md
+++ b/docs/adr/0011-carry-the-native-entry-behind-a-type-class.md
@@ -1,0 +1,67 @@
+# 11. Carry the native entry on `ArchiveEntry` behind a type class
+
+Date: 2024-04-12
+
+## Status
+
+Accepted
+
+## Context
+
+`ArchiveEntry` models what every archive format has in common: a name, a size, a directory
+flag, some timestamps. Real formats carry much more — tar has uid, gid, mode and extra
+fields; zip has comments and extra records.
+
+The first attempt at moving entries between formats converted through those four common
+fields:
+
+```scala
+def to[B](implicit archiveEntry: ArchiveEntry[A], ctor: ArchiveEntryConstructor[B]): B =
+  ctor.from(self)
+```
+
+Reading a tar entry and writing it straight back out therefore silently dropped everything
+the model did not know about. For a copy operation — the most obvious thing to do with an
+archive — that is data loss.
+
+## Decision
+
+Keep the native entry on the model and convert through type classes rather than through the
+common fields:
+
+```scala
+case class ArchiveEntry[+Size[A] <: Option[A], +Underlying](
+    name: String, ..., private val underlying: Underlying = ())
+```
+
+The field is `private` and shadowed by a method that requires evidence:
+
+- `ArchiveEntryFromUnderlying[Size, U]` builds an `ArchiveEntry` when reading
+- `ArchiveEntryToUnderlying[U]` produces the native entry when writing
+
+A tar-to-tar or zip-to-zip copy then preserves everything the format supports, while a
+cross-format copy or a synthesised entry degrades to the common core.
+
+Getting this right needed a follow-up. The first version returned the *original* native entry
+even after `withName` had changed the name, so a renamed entry archived under its old name.
+The fix copies the native entry — for tar by round-tripping its 512-byte header — and
+re-applies the changed fields. There is a regression test for exactly that.
+
+## Consequences
+
+- Copying between archives of the same format is lossless without `ArchiveEntry` having to
+  model every field of every format.
+- Users cannot accidentally couple to a format-specific type, since the native entry is only
+  reachable with the right evidence in scope.
+- There is a documented limitation, still carried as a comment at the top of `Tar.scala` and
+  `Zip.scala`: the underlying information is lost if the name or directory flag changes in a
+  way that makes the copy invalid.
+- `ArchiveEntryFromUnderlying` always produces `ArchiveEntry[Option, U]` — reading never
+  guarantees a size, which is why every unarchiver is `Unarchiver[F, Option, _]` (ADR 0009).
+
+## References
+
+- `dc4df41` "convert between archive entries" (2023-01-13) — the lossy first attempt
+- `e675fe9` "refactoring" (2024-04-12) — case class, `Underlying`, the two type classes
+- `98e9b70` "fix underlying information being incorrect" (2024-04-12) — defensive copies
+- `core/src/main/scala/de/lhns/fs2/compress/ArchiveEntry.scala`

--- a/docs/adr/0012-deprecate-zip-archiver-make.md
+++ b/docs/adr/0012-deprecate-zip-archiver-make.md
@@ -1,0 +1,53 @@
+# 12. Deprecate `ZipArchiver.make` for `makeDeflated` and `makeStored`
+
+Date: 2024-10-11
+
+## Status
+
+Accepted
+
+## Context
+
+`ZipArchiver.make` took the compression method as a raw `Int` from `java.util.zip`:
+
+```scala
+def make[F[_]: Async, Size[A] <: Option[A]](
+    method: Int = ZipOutputStream.DEFLATED,
+    chunkSize: Int = Defaults.defaultChunkSize
+): ZipArchiver[F, Size]
+```
+
+Once ADR 0009 parameterised the archiver over `Size`, this signature let the two parameters
+be chosen independently — including `make[IO, Option](ZipOutputStream.STORED)`, a STORED
+archiver that does not require an entry size. STORED needs the size in the local header, so
+that combination cannot work, and nothing stopped anyone writing it.
+
+## Decision
+
+Deprecate `make` and expose the two combinations that are actually valid:
+
+```scala
+@deprecated("Use makeDeflated or makeStored instead", "2.2")
+def make[F[_]: Async, Size[A] <: Option[A]](method: Int = ..., chunkSize: Int = ...)
+
+def makeDeflated[F[_]: Async](chunkSize: Int = ...): ZipArchiver[F, Option]
+def makeStored[F[_]: Async](chunkSize: Int = ...): ZipArchiver[F, Some]
+```
+
+The method and the size requirement now travel together and cannot be mismatched.
+
+This is the freedom ADR 0005 was set up to allow: because constructors are private and all
+construction goes through factories, the factory set could be reshaped without touching the
+class.
+
+## Consequences
+
+- The invalid combination is no longer expressible.
+- `make` is still present. Under `early-semver` (ADR 0017) removing it would be a breaking
+  change, so it stays for the 2.x line — it has already outlived several minor releases.
+- An untyped `Int` is gone from the public API, and the two names document what they do.
+
+## References
+
+- `718b227` "Mark `Zip.make` factory function as deprecated" (2024-10-11)
+- `zip/src/main/scala/de/lhns/fs2/compress/Zip.scala`

--- a/docs/adr/0013-test-with-munit-cats-effect.md
+++ b/docs/adr/0013-test-with-munit-cats-effect.md
@@ -1,0 +1,46 @@
+# 13. Test with munit-cats-effect
+
+Date: 2024-06-07
+
+## Status
+
+Accepted
+
+## Context
+
+Tests ran on munit plus `munit-tagless-final`, a small library by the same author, through a
+hand-written base class in `core`:
+
+```scala
+abstract class IOSuite extends TaglessFinalSuite[IO] {
+  override protected def toFuture[A](f: IO[A]): Future[A] =
+    f.unsafeToFuture()(unsafe.IORuntime.global)
+}
+```
+
+Every suite ran against the global `IORuntime` via `unsafeToFuture`. That works for a
+round-trip test, but it means no per-test runtime, no timeout supervision from the framework,
+and no effectful assertion helpers.
+
+## Decision
+
+Replace both test dependencies with `org.typelevel::munit-cats-effect`, delete `IOSuite`, and
+have every suite extend `CatsEffectSuite`.
+
+## Consequences
+
+- Tests are pinned to `IO` rather than abstract over an effect type. In practice every suite
+  already used `IO`, so nothing was lost.
+- One fewer bespoke dependency, and the standard Typelevel testing setup that contributors
+  will recognise.
+- This turned out to be a prerequisite for everything in ADR 0018 and ADR 0020. The
+  cancellation suites depend on the cats-effect test-runtime integration — `munitIOTimeout`
+  supervision in particular — which the old `IOSuite` did not provide. A suite that has to
+  cancel fibers and detect deadlocks cannot be built on `unsafeToFuture` against a global
+  runtime.
+
+## References
+
+- `8c9db92` "use munit-cats-effect" (2024-06-07)
+- `core/src/test/scala/de/lhns/fs2/compress/CancellationSuite.scala` — the current suites
+  built on `CatsEffectSuite`

--- a/docs/adr/0014-codec-modules-follow-a-fixed-shape.md
+++ b/docs/adr/0014-codec-modules-follow-a-fixed-shape.md
@@ -1,0 +1,57 @@
+# 14. Codec modules follow a fixed shape
+
+Date: 2024-10-02
+
+## Status
+
+Accepted
+
+## Context
+
+New codecs mostly arrive as outside contributions — lz4 and snappy both did, from different
+contributors three months apart. A contributor adding one has to work out the module layout,
+the class and companion conventions, the stream plumbing and the test style, none of which
+were written down.
+
+They are all derivable from the existing modules, and in practice both contributions were
+structurally identical to what was already there, which is the point: the shape is uniform
+enough to copy.
+
+## Decision
+
+Accept new codecs as modules that follow the established shape, rather than special-casing
+each one:
+
+1. `build.sbt`: a version in the `V` block, an `.aggregate(...)` line on `root`, and a
+   `projectMatrix` module depending on `core % "compile->compile;test->test"`, named
+   `fs2-compress-<name>`, JVM-only.
+2. One source file with a `Compressor` and a `Decompressor`, constructors private.
+3. Compression through `readOutputStream` + `writeOutputStream`, decompression through
+   `toInputStream` + `readInputStream` (ADR 0001).
+4. A companion with `apply` summoning and `make` constructing, `chunkSize` defaulted to
+   `Defaults.defaultChunkSize` (ADR 0005).
+5. A round-trip suite: 1 MiB of random bytes, compress, decompress, compare.
+6. A line in the README dependency block.
+
+Codec-specific configuration is exposed where the format has genuinely distinct modes rather
+than being flattened away — snappy takes a `WriteMode`/`ReadMode` ADT covering basic, framed
+and Hadoop-compatible, because those produce incompatible bytes.
+
+## Consequences
+
+- Reviewing a new codec is mostly checking it matches the shape.
+- The uniformity is what makes the sweeping changes in ADR 0018 and ADR 0019 tractable: the
+  same edit applied to every compressor because every compressor was the same code.
+- Steps 3 and 5 have since moved on. Compression now goes through
+  `OutputStreams.throughOutputStream` (ADR 0019), and a codec is also expected to pass the
+  shared cancellation suite. A new module copied from an old one will not automatically be
+  cancellable.
+- The library carries whatever compatibility quirks the contributors needed. Lz4 uses frame
+  encoding and is explicitly not Spark-compatible; snappy's Hadoop mode exists precisely to
+  be.
+
+## References
+
+- `de033f0` "Support LZ4" (2024-10-02), PR #145 — Erik van Oosten
+- `8c44ac2` "Support snappy compression." (2025-01-08), PR #191 — Rodrigo Molina
+- `12d1c83` "Add Brotli4J submodule" (2024-10-11), PR #152 — Jakob Merrild

--- a/docs/adr/0015-second-brotli-implementation-for-compression.md
+++ b/docs/adr/0015-second-brotli-implementation-for-compression.md
@@ -1,0 +1,53 @@
+# 15. Ship a second brotli implementation for compression
+
+Date: 2024-10-11
+
+## Status
+
+Accepted
+
+## Context
+
+The `brotli` module is built on `org.brotli:dec` — Google's reference JVM port, whose
+artifact name says what it is. It decodes only. There has never been a `BrotliCompressor` in
+that module, and issue #105 asked for one:
+
+> The Brotli module only has a decompressor.
+
+There is no compressor to add: the dependency does not contain one. Adding brotli compression
+means a different library, and brotli4j is the usual JVM choice. It also bundles native
+binaries for each supported platform, which is a meaningful weight to put on users who only
+ever decompress.
+
+## Decision
+
+Add a separate `brotli4j` module providing both `Brotli4JCompressor` and
+`Brotli4JDecompressor`, and keep the existing `brotli` module unchanged.
+
+The first proposal replaced the backing library in place. That PR was closed and resubmitted
+as a new module instead, which is the decision worth recording: `org.brotli:dec` was kept
+deliberately, not by omission.
+
+## Considered options
+
+- **Swap `brotli` onto brotli4j.** One brotli module, compression for everyone. Rejected: it
+  forces brotli4j's native binaries on existing decompress-only users, changing the
+  dependency footprint of a module they already depend on.
+- **Add a second module.** Chosen, following the precedent already set for zip (ADR 0007).
+
+## Consequences
+
+- Two brotli modules with different capabilities: `brotli` decodes, `brotli4j` does both.
+  Users choosing brotli have to know which they want.
+- Existing users' dependencies are unchanged.
+- `brotli4j` exposes `Encoder.Parameters`, so quality, window size and mode are
+  configurable — the wider surface that comes with a fuller implementation.
+- The README's decompression example still lists `BrotliDecompressor`, and the compression
+  examples do not mention brotli at all. Worth fixing.
+
+## References
+
+- Issue #105 "Add BrotliCompressor API"
+- PR #151 "Add brotli compressor" — closed, replaced by PR #152
+- `12d1c83` "Add Brotli4J submodule" (2024-10-11)
+- `90d7b48` "publish brotli4j module" — adds the missing `.aggregate` line

--- a/docs/adr/0016-track-the-scala-3-lts-line.md
+++ b/docs/adr/0016-track-the-scala-3-lts-line.md
@@ -1,0 +1,44 @@
+# 16. Track the Scala 3 LTS line
+
+Date: 2025-01-23
+
+## Status
+
+Accepted
+
+## Context
+
+Automated dependency updates had been carrying the build forward along the Scala 3 "Next"
+series through 2024 — 3.4.1, 3.4.2, 3.4.3, 3.5.0, 3.5.1, 3.5.2, 3.6.2 — because from a bot's
+point of view a newer version is simply an update.
+
+For a library that is the wrong direction. Scala 3 minor releases are not forward binary
+compatible, so an artifact built on 3.6.2 cannot be consumed by an application on 3.3.x,
+while an artifact built on the LTS line can be consumed by everyone.
+
+## Decision
+
+Pin the Scala 3 axis to the 3.3.x LTS line, and take the downgrade required to get there:
+
+```diff
+-lazy val scalaVersions = Seq("3.6.2", "2.13.15", "2.12.20")
++lazy val scalaVersions = Seq("3.3.4", "2.13.15", "2.12.20")
+```
+
+Updates within the LTS line are still accepted; the build has moved 3.3.4 → 3.3.8 since.
+
+Scala 2.13 and 2.12 remain supported.
+
+## Consequences
+
+- Applications on any supported Scala 3 version can use the published artifacts.
+- The library cannot use language features newer than the LTS line.
+- Dependency-update PRs that propose a Next-series version have to be declined rather than
+  merged, which is a standing bit of maintenance attention.
+- Three Scala versions across eleven modules, two of them also cross-built to Scala.js, is a
+  large matrix to keep green.
+
+## References
+
+- `08519ee` "scala 3 lts" (2025-01-23)
+- `build.sbt` — `scalaVersions`

--- a/docs/adr/0017-publish-to-sonatype-central-under-early-semver.md
+++ b/docs/adr/0017-publish-to-sonatype-central-under-early-semver.md
@@ -1,0 +1,54 @@
+# 17. Publish to Sonatype Central under early-semver
+
+Date: 2023-01-11
+
+## Status
+
+Accepted
+
+## Context
+
+The library publishes eleven artifacts across three Scala versions and two platforms, so
+releasing has to be automated and the versioning has to tell users what is safe to upgrade.
+
+## Decision
+
+**Version scheme.** `versionScheme := Some("early-semver")`, set in the initial commit and
+never changed. It tells coursier and sbt how to judge compatibility: within 1.x and above,
+`2.2.0` and `2.3.0` are compatible; in 0.x, a minor bump is breaking.
+
+**Version source.** The version comes from the CI tag rather than being committed:
+
+```scala
+version := {
+  val Tag = "refs/tags/v?([0-9]+(?:\\.[0-9]+)+(?:[+-].*)?)".r
+  sys.env.get("CI_VERSION").collect { case Tag(tag) => tag }.getOrElse("0.0.1-SNAPSHOT")
+}
+```
+
+Publishing a GitHub release runs `sonatypeBundleClean; publishSigned; sonatypeBundleRelease`
+with `CI_VERSION` set, so the tag is the single source of truth and a local build is always a
+snapshot.
+
+**Host.** Originally OSSRH on `s01.oss.sonatype.org`, migrated to Sonatype Central when OSSRH
+was retired.
+
+A follow-up the same evening lifted `version` to `ThisBuild` scope, because
+`sonatypeBundleRelease` names the staging bundle from the build-level version and that scope
+was still reporting a stale default.
+
+## Consequences
+
+- Releasing is tagging. There is no version to bump in a commit and no chance of a mismatch
+  between tag and artifact.
+- Early-semver is what makes deprecation the right answer rather than removal: the
+  deprecated `ZipArchiver.make` (ADR 0012) must stay for the whole 2.x line.
+- The published surface is eleven artifacts per release, so any breaking change is expensive
+  to roll out and expensive to undo.
+
+## References
+
+- `9ed3d84` (2023-01-11) — `versionScheme` and the `CI_VERSION` regex, from day one
+- `df0629e` "sonatype central" (2025-05-13) — host migration
+- `b449d3a` "set ThisBuild / version" (2025-05-13)
+- `build.sbt`, `.github/workflows/build.yml`

--- a/docs/adr/0018-close-codec-streams-inside-the-stream.md
+++ b/docs/adr/0018-close-codec-streams-inside-the-stream.md
@@ -1,0 +1,77 @@
+# 18. Close codec streams inside the stream, not in a `Resource`
+
+Date: 2026-08-24
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #113 reported that a program decompressing a zip could not be stopped with Ctrl-C. The
+fiber was cancelled and never finished.
+
+The cause is narrower than it first looks, and it is not only `closeEntry`. `Async[F].blocking`
+cannot be interrupted, and **both halves of a `Resource` are uncancelable regions**. Any write
+or read performed in one of them therefore runs to completion no matter what, and once the
+consumer has stopped draining the `fs2.io.readOutputStream` pipe, "to completion" means never.
+
+Thread dumps put the blocked frame in three genuinely different places, which is why fixing
+one site would not have been enough:
+
+| Where | Frame |
+|---|---|
+| Entry finalizer, draining the rest of the entry from a live upstream | `ZipInputStream.closeEntry()` |
+| Resource **acquire**, writing a 512-byte header into a full pipe | `TarArchiveOutputStream.putArchiveEntry()` |
+| Outer finalizer, flushing the final block into a pipe nobody reads | `BZip2CompressorOutputStream.close()` |
+
+## Decision
+
+Stop performing these writes inside uncancelable regions.
+
+- The entry header and trailer, and the close of the underlying stream, move out of
+  `Resource` and into the stream itself as `Async[F].interruptible`. There an interrupt lands.
+  On the happy path the bytes and their order are unchanged.
+- The `Resource` release becomes a uniform safety net for the paths where the stream did not
+  get that far. It closes the fs2 `OutputStream` **first**, which is what makes it
+  non-blocking: writes to a closed `PipedStreamBuffer` are discarded rather than
+  backpressured, so `close()` returns even with nobody reading, and still releases what it
+  owns — `Deflater.end()`, `ZSTD_freeCStream`, brotli4j's encoder.
+- `ZipUnarchiver` drops its per-entry `closeEntry()` finalizer entirely. `getNextEntry()`
+  calls `closeEntry()` itself before advancing, so it was redundant on the happy path and
+  pure liability on every other one.
+
+Closing the pipe first is not redundant with what fs2 already does. fs2 closes it in a
+`guaranteeCase` *around* the body, so on cancellation the two closes deadlock: the release
+blocks writing the trailer, and the close that would unblock it cannot run until the release
+returns. Removing that one line locally brought back ten failures.
+
+## Considered options
+
+- **Skip `close()` on cancellation.** Avoids the hang, but leaks whatever the stream owns,
+  including native memory.
+- **Use `Async[F].interruptible` in the release.** Does not work: finalizers run in an
+  uncancelable region, so the interrupt is never delivered. Tried and measured.
+- **Branch on `ExitCase` and only close on success.** Insufficient. fs2 reports
+  `ExitCase.Succeeded` for early downstream termination, so `.take(n)` and
+  `ArchiveSingleFileDecompressor`'s `.head` — the path in the issue — would still drain the
+  entry. It also leaves the outer `close()` in place, which blocks on its own.
+- **Move the close into the stream, with the release as a fallback.** Chosen.
+
+## Consequences
+
+- Cancelling a compression or archiving stream completes, across every module.
+- On cancellation the output is truncated: no central directory, no EOF records, no frame
+  epilogue. That is correct — the only way to reach this path is that whoever was reading
+  those bytes has already gone.
+- **Cancellation latency is bounded, not zero.** `fs2.io.readInputStream` still reads inside
+  `F.blocking`, so a cancellation waits for the read in flight. Codecs that need a large
+  contiguous block per read can take a while on a slow source. Fixing that needs fs2's
+  `readInputStreamCancelable`, which is `private[io]`.
+- The success path is byte-for-byte identical, which the pre-existing round-trip suites pin.
+
+## References
+
+- Issue #113 "zip decompressor is not cancellable"
+- PRs #339 and #341, commit `a5a9bed` "Make archivers and compressors cancelable"
+- ADR 0019 for the shared helper, ADR 0020 for how this is tested

--- a/docs/adr/0019-share-the-output-stream-plumbing.md
+++ b/docs/adr/0019-share-the-output-stream-plumbing.md
@@ -1,0 +1,61 @@
+# 19. Share the `readOutputStream` plumbing in `OutputStreams`
+
+Date: 2026-08-24
+
+## Status
+
+Accepted
+
+## Context
+
+Every compressor and archiver had its own copy of the same plumbing: open
+`fs2.io.readOutputStream`, build the codec stream on top of the pipe, feed it with
+`writeOutputStream`, close it. Five plain compressors differed only in the constructor call.
+
+That was tolerable while the plumbing was four lines. ADR 0018 made it subtle — the close has
+to happen inside the stream, the release has to close the pipe before the stream, and errors
+from the release have to be discarded — and none of that is guessable from reading a call
+site. Eight copies of a subtlety is eight chances to get it wrong, and a new codec module
+copied from an old one would silently not be cancellable.
+
+## Decision
+
+Put the plumbing in `OutputStreams` in `core`, with two entry points named after their fs2
+counterparts:
+
+- `readWrappedOutputStream(chunkSize)(wrapOutputStream)(write)` — like
+  `fs2.io.readOutputStream`, except the stream handed to `write` is the caller's wrapper
+  around the pipe, and closing it can be cancelled. Used by the three archivers, which supply
+  their own entry loop.
+- `throughOutputStream(chunkSize)(wrapOutputStream)` — the same as a `Pipe`, for codecs that
+  just write everything they are given. Used by the five plain compressors, one line each.
+
+`readOutputStream` does not exist on Scala.js, so this needs `fs2-io`, which `core` did not
+depend on. Rather than give it up or push the helper elsewhere, `fs2-io` is added to `core`'s
+**JVM row only** and the file lives in `core/src/main/scalajvm`, with the reason recorded in
+`build.sbt`:
+
+```scala
+// fs2-io is JVM only here: OutputStreams wraps fs2.io.readOutputStream, which does not exist on JS.
+```
+
+The Scala.js artifact is unchanged.
+
+## Consequences
+
+- The tricky part is written down once, next to the code that does it, instead of eight
+  times.
+- `src/main` came out smaller than before ADR 0018 despite gaining the fix.
+- **JVM consumers of the `core` artifact now get `fs2-io` transitively.** Every other module
+  already depends on it, so in practice this affects only someone depending on `core` alone,
+  but it is a change to a published artifact's dependencies and should not be undone lightly.
+- `core` is now split across two source directories, which is a wrinkle for anyone adding to
+  it: cross-platform code in `src/main/scala`, JVM-only in `src/main/scalajvm`.
+- ADR 0014's module shape is superseded on this point — a new codec should call
+  `OutputStreams.throughOutputStream` rather than copy the plumbing.
+
+## References
+
+- PRs #339 and #341, commit `a5a9bed`
+- `core/src/main/scalajvm/de/lhns/fs2/compress/OutputStreams.scala`
+- `build.sbt` — the `core` module's `jvmPlatform` settings

--- a/docs/adr/0020-assert-cancellation-by-counting-not-timing.md
+++ b/docs/adr/0020-assert-cancellation-by-counting-not-timing.md
@@ -1,0 +1,74 @@
+# 20. Assert cancellation by counting bytes, not by elapsed time
+
+Date: 2026-08-24
+
+## Status
+
+Accepted
+
+## Context
+
+The bug in ADR 0018 had gone unfixed for a long time partly because nobody could write a
+convincing test for it. The contributor who diagnosed it said as much: *"Not sure how to
+easily test this in an automated test."*
+
+An earlier attempt used `Stream.never` as a stalled source. That looks reasonable and is
+wrong: it parks the fiber inside an uninterruptible `IO.blocking(read)`, where cancellation
+can never be delivered no matter how good the fix is. The test would hang with a correct
+implementation, so it proves nothing.
+
+That is the trap these tests have to avoid. Whether a cancellation test asserts something
+achievable depends entirely on **where the fiber is parked**:
+
+| Parked in | Can cancellation be delivered? |
+|---|---|
+| A mid-stream read that will not return | **No.** Nothing the library does can help. |
+| A finalizer draining or flushing bytes | **Yes.** That is the bug. |
+
+Both cases were confirmed by thread dump rather than argument — zip parks in
+`ZipInputStream.closeEntry()` inside a finalizer, snappy parks in `SnappyInputStream.read`
+mid-stream.
+
+## Decision
+
+Two different techniques, because the two symptoms are observable in different ways.
+
+**Reading is checked by counting.** The source is entirely in memory, so nothing blocks. The
+stream is stopped where the test wants by parking on a `Deferred` that is never completed —
+parking like that *can* be cancelled, so the cancellation takes effect at once and the source
+stops being pulled. The test counts bytes taken from the source before cancelling and again
+afterwards. A finalizer that drains reads the rest of the entry in between; one that does not
+reads nothing. No sleeping, no timing assertion, nothing to be flaky.
+
+Counting the **difference** rather than the total is what makes this work for every codec.
+Snappy, bzip2, lz4 and brotli read a whole internal block before producing any output, and
+that read-ahead happens before the cancellation — an absolute bound flags them wrongly.
+
+**Writing is checked by waiting**, because its symptom is a stream that never finishes and a
+deadline is the only way to see that. The budget is a deadlock detector, not a
+synchronisation point: ten seconds against milliseconds of real work. The pipe is shrunk to
+64 bytes so that a consumer which stops draining makes the next write block by construction
+rather than by timing.
+
+Cancellation is observed with `fiber.cancel.start` plus a cancelable `join.timeout`.
+`fiber.cancel.timeout(...)` would hang, because `cancel` is `IO.uncancelable` and `timeout`
+is `race`, which waits for the loser's cancellation — exactly the situation under test.
+
+## Consequences
+
+- The read-side tests run in about 0.06s each with no timing assumptions.
+- Every module runs every test. An earlier timing-based version needed a per-codec opt-out
+  for the block-reading decompressors; the counting version does not.
+- Gzip is included deliberately as a control. It is pure fs2 with no blocking finalizer, so
+  it passes both before and after the fix, which shows the harness is not asserting something
+  universally impossible.
+- The write-side budget is still a timeout. It cannot be removed without a way to observe
+  "never finishes" that does not involve waiting.
+- A failing write-side test leaks a blocked thread. That is the price of reporting a failure
+  instead of hanging the suite, and it only happens on an already-red run.
+
+## References
+
+- PR #335, commit `8bedd40` "Add cancellation tests for all archivers and compressors"
+- `core/src/test/scala/de/lhns/fs2/compress/CancellationSuite.scala`
+- ADR 0018 for the fix these tests pin

--- a/docs/adr/0021-skipping-entries-and-stale-reads.md
+++ b/docs/adr/0021-skipping-entries-and-stale-reads.md
@@ -1,0 +1,79 @@
+# 21. Let entries be skipped, and fail when reading data the archive has passed
+
+Date: 2026-08-24
+
+## Status
+
+Proposed — PR #342 is open.
+
+## Context
+
+Issue #295: pulling archive entries without reading their data never terminated the stream.
+Inspecting the names in a downloaded zip — an ordinary thing to want — simply hung.
+
+All three unarchivers shared a handshake that put `Stream.exec(deferred.get)` in the outer
+stream between one entry and the next, where the `Deferred` was only completed by running
+that entry's data stream **to its end**. Pull the next entry without finishing the current
+one's data and it waited forever. It was also broader than the issue title suggested: reading
+only *part* of an entry hung just as surely as skipping it.
+
+The handshake was never needed to keep the archive positioned correctly. All three underlying
+libraries already read past the rest of the current entry while looking for the next header —
+confirmed in the bytecode, not assumed:
+
+| | |
+|---|---|
+| `java.util.zip.ZipInputStream.getNextEntry()` | calls `closeEntry()`, which loops `read()` to EOF |
+| `TarArchiveInputStream.getNextTarEntry()` | `IOUtils.skip(this, Long.MAX_VALUE)` + `skipRecordPadding()` |
+| zip4j's `getNextEntry()` | calls `readUntilEndOfEntry()` |
+
+So it bought nothing except the deadlock. What it did prevent, by making it impossible, is
+reading an entry's data *after* the archive has moved past it — where the bytes are gone and
+a read would quietly return whatever the archive is positioned at now.
+
+## Decision
+
+Two mistakes, two different answers:
+
+| Consumer does | Result |
+|---|---|
+| Moves to the next entry with data unread | the data is skipped, the stream continues |
+| Reads data the archive has moved past | `IllegalStateException` |
+
+Skipping is allowed because an archive is read in one pass and there is no alternative;
+refusing would make listing entry names an error. The stale read fails because there is no
+correct answer to return, and silence there would trade a hang for corruption.
+
+A `Ref[F, Long]` records which entry the archive is positioned at, set *before* the archive
+advances so a stale data stream fails the moment it commits to moving on. The check runs per
+chunk, so data streams read concurrently with the entries are caught too, not just the
+sequential case.
+
+The entry loop was identical in all three unarchivers and now lives in `Unarchiver.entries`,
+beside the trait, in the same way the shared size check lives in `Archiver` (ADR 0010).
+
+## Considered options
+
+- **Leave it stuck.** A hang is the worst of the three: silent, no clue where to look, and it
+  fires on partial reads as well as skips.
+- **Throw when advancing past unread data.** Turns the hang into an error, but makes the
+  reported use case — listing entry names — an error rather than working.
+- **Skip silently, no exception.** Fixes the issue with the smallest change, but a stale read
+  then returns the next entry's bytes.
+- **Skip on advance, throw on stale read.** Chosen.
+
+## Consequences
+
+- Listing entries, reading part of an entry, and skipping entries all terminate.
+- Misuse fails loudly and immediately instead of returning wrong bytes.
+- Skipping costs the I/O of reading past the skipped data. Unavoidable in a one-pass format.
+- That skip happens inside an uninterruptible `Async[F].blocking` call, so skipping a large
+  entry lengthens cancellation latency — the bounded-latency caveat from ADR 0018.
+- Nothing in the repo built a multi-entry archive before this, which is why the issue had no
+  coverage. The shared suite now does.
+
+## References
+
+- Issue #295 "Not pulling zip entry data stream causes a non-terminating stream"
+- PR #296 — the same diagnosis and conclusion, from Hugo van Rijswijk
+- PR #342, `core/src/main/scala/de/lhns/fs2/compress/Unarchiver.scala`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,58 @@
+# Architecture Decision Records
+
+Decisions that shaped this library and would be expensive or confusing to reverse without
+knowing why they were made. Most were reconstructed from the commit history and closed pull
+requests; the later ones were recorded as they were taken.
+
+Each record is one file, numbered in the order the decision was made, and follows the same
+shape: **Date**, **Status**, **Context**, **Decision**, **Consequences**. A **Considered
+options** section appears only where the alternatives are actually on record — several of
+these decisions went through an attempt that was committed and then abandoned, and those are
+worth keeping. Where no alternatives are listed, none were found; the section is not padded
+with invented ones.
+
+Statuses used here: **Accepted**, **Proposed** (decided, not yet merged), and **Superseded
+by NNNN**. A record is not edited once accepted — if a decision changes, a new record
+supersedes it.
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-bridge-java-io-streams-into-fs2.md) | Bridge `java.io` codec streams into fs2, and default to a 64 KiB chunk | Accepted |
+| [0002](0002-one-module-per-codec.md) | Give each codec its own module | Accepted |
+| [0003](0003-cross-build-to-scala-js-where-possible.md) | Cross-build to Scala.js only where the codec allows it | Accepted |
+| [0004](0004-four-traits-and-single-file-adapters.md) | Model the four operations as traits, with single-file adapters | Accepted |
+| [0005](0005-apply-summons-make-constructs.md) | `apply` summons, `make` constructs, constructors are private | Accepted |
+| [0006](0006-require-compression-instance-for-gzip.md) | Require `Compression[F]` for gzip rather than `LiftIO` | Accepted |
+| [0007](0007-second-zip-implementation-for-encryption.md) | Ship a second zip implementation for encryption | Accepted |
+| [0008](0008-declare-entry-size-instead-of-buffering.md) | Stream archive entries by declaring the size up front | Accepted |
+| [0009](0009-archiver-type-states-whether-size-is-required.md) | Let the archiver's type say whether a size is required | Accepted |
+| [0010](0010-verify-the-declared-entry-size.md) | Verify the declared entry size while archiving | Accepted |
+| [0011](0011-carry-the-native-entry-behind-a-type-class.md) | Carry the native entry on `ArchiveEntry` behind a type class | Accepted |
+| [0012](0012-deprecate-zip-archiver-make.md) | Deprecate `ZipArchiver.make` for `makeDeflated` and `makeStored` | Accepted |
+| [0013](0013-test-with-munit-cats-effect.md) | Test with munit-cats-effect | Accepted |
+| [0014](0014-codec-modules-follow-a-fixed-shape.md) | Codec modules follow a fixed shape | Accepted |
+| [0015](0015-second-brotli-implementation-for-compression.md) | Ship a second brotli implementation for compression | Accepted |
+| [0016](0016-track-the-scala-3-lts-line.md) | Track the Scala 3 LTS line | Accepted |
+| [0017](0017-publish-to-sonatype-central-under-early-semver.md) | Publish to Sonatype Central under early-semver | Accepted |
+| [0018](0018-close-codec-streams-inside-the-stream.md) | Close codec streams inside the stream, not in a `Resource` | Accepted |
+| [0019](0019-share-the-output-stream-plumbing.md) | Share the `readOutputStream` plumbing in `OutputStreams` | Accepted |
+| [0020](0020-assert-cancellation-by-counting-not-timing.md) | Assert cancellation by counting bytes, not by elapsed time | Accepted |
+| [0021](0021-skipping-entries-and-stale-reads.md) | Let entries be skipped, and fail when reading data the archive has passed | Proposed |
+
+## Threads worth following
+
+Several records only make sense together.
+
+**How an entry knows its size.** 0008 introduced the `Size` parameter to stop buffering whole
+entries in memory, 0009 refined which archivers demand it, 0010 added the check that the
+declared size is true, and 0012 removed the factory that let the invalid combination be
+expressed.
+
+**Why blocking streams are hard here.** 0001 chose to wrap `java.io` implementations, which
+is where every later difficulty comes from: 0018 for cancellation, 0019 for the shared
+plumbing that fixed it in one place, 0020 for how it is tested, and 0021 for what happens
+when a consumer skips an entry.
+
+**When to add a module rather than change one.** 0002 established one artifact per codec,
+0007 and 0015 both applied it by adding a second implementation of a format rather than
+replacing the first, and 0014 wrote down the shape a new module follows.


### PR DESCRIPTION
Twenty-one architecture decision records, one per file, in the order the decisions were made. Docs only — no build impact.

Three years of design decisions existed only in commit messages and closed PRs. Why every codec is its own artifact, why `ArchiveEntry` carries a higher-kinded `Size` parameter, why there are two zip modules and two brotli modules, why the streams are closed where they are — all of it had to be reconstructed from `git log`.

Each record is Context / Decision / Consequences, and cites the commits, PRs and issues it came from so the account can be checked rather than taken on trust. A **Considered options** section appears only where the alternatives are genuinely on record — for the 2023 commits I can show what was done and why, but inventing a list of rejected alternatives would be fiction. Where a real attempt was made and abandoned, it is recorded:

- the `LiftIO` constraint on gzip, in place four months before being replaced by `Compression[F]` (0006)
- the contravariant `-Size`, committed and reverted a day later (0009)
- the twenty-four minutes when zstd-jni was demoted to `% Test` scope, which shrank the artifact and broke it (0002)
- the brotli PR that was closed in favour of adding a module rather than swapping the library (0015)

## The set

Founding: bridging `java.io` into fs2 (0001), one module per codec (0002), selective Scala.js cross-building (0003), the four traits (0004), `apply` summons / `make` constructs (0005), `Compression[F]` over `LiftIO` (0006).

Archive entries: zip4j for encryption (0007), declaring the entry size instead of buffering (0008), letting the archiver's type state the requirement (0009), verifying the declared size (0010), carrying the native entry behind a type class (0011), deprecating `ZipArchiver.make` (0012).

Process and build: munit-cats-effect (0013), the codec module shape (0014), brotli4j for compression (0015), the Scala 3 LTS line (0016), Sonatype Central under early-semver (0017).

Recent: closing codec streams inside the stream (0018), the shared `OutputStreams` plumbing (0019), counting bytes rather than timing to assert cancellation (0020), and skipping entries with a failure on stale reads (0021 — **Proposed**, since #342 is still open).

## Two corrections found while writing

Worth flagging because both were plausible and wrong:

- `b6e683b` "Fix incorrect headers order" is a **README markdown heading** fix, not an archive-header change. It is not cited.
- `versionScheme := early-semver` and `Defaults.defaultChunkSize` are **day-one** decisions from the initial commit, not later additions.

The `Size` parameter also turns out to have a better story than the obvious one: it exists because of issue #77, an out-of-memory bug caused by `chunkAll` buffering whole entries — not because someone wanted to be clever with types. That is 0008, and the refinement six months later is 0009.

## Checks

Every commit SHA, PR and issue number cited resolves; every internal link and `ADR NNNN` cross-reference resolves; `build.sbt` does not reference `docs`, and `sbt compile` is unaffected.
