### PR TITLE
Import a default instance instead of declaring one

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,19 @@ Compression can be abstracted over using the `Compressor` typeclass. Adapt the f
 ```scala
 import cats.effect.Async
 import de.lhns.fs2.compress._
+import de.lhns.fs2.compress.GzipCompressor.default._
+import fs2.compression.Compression
+import fs2.io.compression._ // gzip needs a Compression[F]; the other codecs do not
 import fs2.io.file.{Files, Path}
 
-// implicit def bzip2[F[_]: Async]: Compressor[F] = Bzip2Compressor.make()
-// implicit def lz4[F[_]: Async]: Compressor[F] = Lz4Compressor.make()
-// implicit def zstd[F[_]: Async]: Compressor[F] = ZstdCompressor.make()
-implicit def gzip[F[_]: Async]: Compressor[F] = GzipCompressor.make()
+// import de.lhns.fs2.compress.Bzip2Compressor.default._
+// import de.lhns.fs2.compress.Lz4Compressor.default._
+// import de.lhns.fs2.compress.ZstdCompressor.default._
+// import de.lhns.fs2.compress.SnappyCompressor.framed._
 
-def compressFile[F[_]: Async](toCompress: Path, writeTo: Path)(implicit compressor: Compressor[F]): F[Unit] =
+def compressFile[F[_]: Async: Compression](toCompress: Path, writeTo: Path)(implicit
+    compressor: Compressor[F]
+): F[Unit] =
   Files[F]
     .readAll(toCompress)
     .through(compressor.compress)
@@ -111,23 +116,40 @@ def compressFile[F[_]: Async](toCompress: Path, writeTo: Path)(implicit compress
     .drain
 ```
 
+`default` is only a shortcut for `make()` with every argument left alone. To configure the codec, build the instance
+yourself and drop the import:
+
+```scala
+implicit val gzipCompressor: GzipCompressor[IO] = GzipCompressor.make(deflateLevel = Some(9))
+```
+
+Annotate it with the concrete type, as above, rather than with `Compressor[IO]`. If both a `default` import and an
+instance annotated as `Compressor[IO]` are in scope, the imported one is more specific and quietly wins, and the
+settings are lost. With the concrete annotation the two compete on equal terms, so Scala 2.12 reports an ambiguity and
+2.13 and 3 prefer the one you wrote.
+
 ### Decompression
 
 Similarly, decompression can be abstracted over using the `Decompressor` typeclass. Adapt the following examples based on which compression algorithm was used to write the source file.
 ```scala
 import cats.effect.Async
 import de.lhns.fs2.compress._
+import de.lhns.fs2.compress.GzipDecompressor.default._
+import fs2.compression.Compression
+import fs2.io.compression._ // gzip needs a Compression[F]; the other codecs do not
 import fs2.io.file.{Files, Path}
 
-// implicit def brotli[F[_]: Async]: Decompressor[F] = BrotliDecompressor.make()
-// implicit def bzip2[F[_]: Async]: Decompressor[F] = Bzip2Decompressor.make()
-// implicit def lz4[F[_]: Async]: Decompressor[F] = Lz4Decompressor.make()
-// implicit def zstd[F[_]: Async]: Decompressor[F] = ZstdDecompressor.make()
-implicit def gzip[F[_]: Async]: Decompressor[F] = GzipDecompressor.make()
+// import de.lhns.fs2.compress.BrotliDecompressor.default._
+// import de.lhns.fs2.compress.Bzip2Decompressor.default._
+// import de.lhns.fs2.compress.Lz4Decompressor.default._
+// import de.lhns.fs2.compress.ZstdDecompressor.default._
+// import de.lhns.fs2.compress.SnappyDecompressor.framed._
 
-def decompressFile[F[_]: Async](toDecompress: Path, writeTo: Path)(implicit decompressor: Decompressor[F]): F[Unit] =
+def decompressFile[F[_]: Async: Compression](toDecompress: Path, writeTo: Path)(implicit
+    decompressor: Decompressor[F]
+): F[Unit] =
   Files[F]
-    .readAll(toCompress)
+    .readAll(toDecompress)
     .through(decompressor.decompress)
     .through(Files[F].writeAll(writeTo))
     .compile
@@ -143,11 +165,14 @@ import cats.effect.Async
 import de.lhns.fs2.compress._
 import fs2.io.file.{Files, Path}
 
-// implicit def tar[F[_]: Async]: Archiver[F, Some] = TarArchiver.make()
-// implicit def zip4j[F[_]: Async]: Archiver[F, Some] = Zip4JArchiver.make()
-implicit def zip[F[_]: Async]: Archiver[F, Option] = ZipArchiver.makeDeflated()
+import de.lhns.fs2.compress.ZipArchiver.default._
 
-def archiveDirectory[F[_]](directory: Path, writeTo: Path)(implicit archiver: Archiver[F, Option]): F[Unit] =
+// import de.lhns.fs2.compress.TarArchiver.default._
+// import de.lhns.fs2.compress.Zip4JArchiver.default._
+
+def archiveDirectory[F[_]: Async](directory: Path, writeTo: Path)(implicit
+    archiver: Archiver[F, Option]
+): F[Unit] =
   Files[F]
     .list(directory)
     .evalMap { path =>
@@ -172,10 +197,15 @@ import cats.effect.Async
 import de.lhns.fs2.compress._
 import fs2.io.file.{Files, Path}
 
-implicit def gzip[F[_]: Async]: Compressor[F] = GzipCompressor.make()
-implicit def tar[F[_]: Async]: Archiver[F, Some] = TarArchiver.make()
+import de.lhns.fs2.compress.GzipCompressor.default._
+import de.lhns.fs2.compress.TarArchiver.default._
+import fs2.compression.Compression
+import fs2.io.compression._
 
-def tarAndGzip[F[_]: Async](directory: Path, writeTo: Path)(implicit archiver: Archiver[F, Some], compressor: Compressor[F]): F[Unit] =
+def tarAndGzip[F[_]: Async: Compression](directory: Path, writeTo: Path)(implicit
+    archiver: Archiver[F, Some],
+    compressor: Compressor[F]
+): F[Unit] =
   Files[F]
     .list(directory)
     .evalMap { path =>
@@ -203,11 +233,16 @@ import cats.effect.Async
 import de.lhns.fs2.compress._
 import fs2.io.file.{Files, Path}
 
-// implicit def tar[F[_]: Async]: Unarchiver[F, Option] = TarUnarchiver.make()
-// implicit def zip4j[F[_]: Async]: Unarchiver[F, Option] = Zip4JUnarchiver.make()
-implicit def zip[F[_]: Async]: Unarchiver[F, Option] = ZipUnarchiver.make()
+import de.lhns.fs2.compress.ZipUnarchiver.default._
 
-def unArchive[F[_]](archive: Path, writeTo: Path)(implicit archiver: Unarchiver[F, Option]): F[Unit] =
+import java.util.zip.ZipEntry
+
+// import de.lhns.fs2.compress.TarUnarchiver.default._
+// import de.lhns.fs2.compress.Zip4JUnarchiver.default._
+
+def unArchive[F[_]: Async](archive: Path, writeTo: Path)(implicit
+    archiver: Unarchiver[F, Option, ZipEntry]
+): F[Unit] =
   Files[F]
     .readAll(archive)
     .through(archiver.unarchive)
@@ -224,10 +259,16 @@ import cats.effect.Async
 import de.lhns.fs2.compress._
 import fs2.io.file.{Files, Path}
 
-implicit def gzip[F[_]: Async]: Decompressor[F] = GzipDecompressor.make()
-implicit def tar[F[_]: Async]: Unarchiver[F, Option] = TarUnarchiver.make()
+import de.lhns.fs2.compress.GzipDecompressor.default._
+import de.lhns.fs2.compress.TarUnarchiver.default._
+import fs2.compression.Compression
+import fs2.io.compression._
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 
-def unArchive[F[_]](archive: Path, writeTo: Path)(implicit archiver: Unarchiver[F, Option], decompressor: Decompress[F]): F[Unit] =
+def unArchive[F[_]: Async: Compression](archive: Path, writeTo: Path)(implicit
+    archiver: Unarchiver[F, Option, TarArchiveEntry],
+    decompressor: Decompressor[F]
+): F[Unit] =
   Files[F]
     .readAll(archive)
     .through(decompressor.decompress)

--- a/brotli/src/main/scala/de/lhns/fs2/compress/Brotli.scala
+++ b/brotli/src/main/scala/de/lhns/fs2/compress/Brotli.scala
@@ -25,4 +25,11 @@ object BrotliDecompressor {
 
   def make[F[_]: Async](chunkSize: Int = defaultChunkSize): BrotliDecompressor[F] =
     new BrotliDecompressor(chunkSize)
+
+  /** A BrotliDecompressor built with all defaults, to be imported where an instance is needed:
+    * `import BrotliDecompressor.default._`
+    */
+  object default {
+    implicit def defaultBrotliDecompressor[F[_]: Async]: BrotliDecompressor[F] = make()
+  }
 }

--- a/brotli4j/src/main/scala/de/lhns/fs2/compress/Brotli4J.scala
+++ b/brotli4j/src/main/scala/de/lhns/fs2/compress/Brotli4J.scala
@@ -24,6 +24,13 @@ object Brotli4JCompressor {
       params: Encoder.Parameters = Encoder.Parameters.DEFAULT
   ): Brotli4JCompressor[F] =
     new Brotli4JCompressor(chunkSize, params)
+
+  /** A Brotli4JCompressor built with all defaults, to be imported where an instance is needed:
+    * `import Brotli4JCompressor.default._`
+    */
+  object default {
+    implicit def defaultBrotli4JCompressor[F[_]: Async]: Brotli4JCompressor[F] = make()
+  }
 }
 
 class Brotli4JDecompressor[F[_]: Async] private (chunkSize: Int) extends Decompressor[F] {
@@ -48,4 +55,11 @@ object Brotli4JDecompressor {
 
   def make[F[_]: Async](chunkSize: Int = defaultChunkSize): Brotli4JDecompressor[F] =
     new Brotli4JDecompressor(chunkSize)
+
+  /** A Brotli4JDecompressor built with all defaults, to be imported where an instance is needed:
+    * `import Brotli4JDecompressor.default._`
+    */
+  object default {
+    implicit def defaultBrotli4JDecompressor[F[_]: Async]: Brotli4JDecompressor[F] = make()
+  }
 }

--- a/brotli4j/src/test/scala/de/lhns/fs2/compress/Brotli4JDefaultInstanceSuite.scala
+++ b/brotli4j/src/test/scala/de/lhns/fs2/compress/Brotli4JDefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class Brotli4JDefaultInstanceSuite extends CatsEffectSuite {
+  import Brotli4JCompressor.default._
+  import Brotli4JDecompressor.default._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(Brotli4JCompressor[IO].compress)
+        .through(Brotli4JDecompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/bzip2/src/main/scala/de/lhns/fs2/compress/Bzip2.scala
+++ b/bzip2/src/main/scala/de/lhns/fs2/compress/Bzip2.scala
@@ -25,6 +25,13 @@ object Bzip2Compressor {
       blockSize: Option[Int] = None,
       chunkSize: Int = Defaults.defaultChunkSize
   ): Bzip2Compressor[F] = new Bzip2Compressor(blockSize, chunkSize)
+
+  /** A Bzip2Compressor built with all defaults, to be imported where an instance is needed:
+    * `import Bzip2Compressor.default._`
+    */
+  object default {
+    implicit def defaultBzip2Compressor[F[_]: Async]: Bzip2Compressor[F] = make()
+  }
 }
 
 class Bzip2Decompressor[F[_]: Async] private (chunkSize: Int) extends Decompressor[F] {
@@ -46,4 +53,11 @@ object Bzip2Decompressor {
 
   def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): Bzip2Decompressor[F] =
     new Bzip2Decompressor(chunkSize)
+
+  /** A Bzip2Decompressor built with all defaults, to be imported where an instance is needed:
+    * `import Bzip2Decompressor.default._`
+    */
+  object default {
+    implicit def defaultBzip2Decompressor[F[_]: Async]: Bzip2Decompressor[F] = make()
+  }
 }

--- a/bzip2/src/test/scala/de/lhns/fs2/compress/Bzip2DefaultInstanceSuite.scala
+++ b/bzip2/src/test/scala/de/lhns/fs2/compress/Bzip2DefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class Bzip2DefaultInstanceSuite extends CatsEffectSuite {
+  import Bzip2Compressor.default._
+  import Bzip2Decompressor.default._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(Bzip2Compressor[IO].compress)
+        .through(Bzip2Decompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/core/src/main/scala/de/lhns/fs2/compress/Archiver.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Archiver.scala
@@ -4,6 +4,12 @@ import cats.effect.{Async, Ref}
 import cats.syntax.all._
 import fs2.{Pipe, Stream}
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Archiver[${F}, ${Size}] in scope. Import a default instance, for example `import ZipArchiver.default._`, or build "
+    + "one with `ZipArchiver.makeDeflated(...)` and make it implicit."
+)
 trait Archiver[F[_], Size[A] <: Option[A]] {
   def archive: Pipe[F, (ArchiveEntry[Size, Any], Stream[F, Byte]), Byte]
 }

--- a/core/src/main/scala/de/lhns/fs2/compress/Compressor.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Compressor.scala
@@ -2,6 +2,12 @@ package de.lhns.fs2.compress
 
 import fs2.Pipe
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Compressor[${F}] in scope. Import a default instance, for example `import GzipCompressor.default._`, or build " +
+    "one with `GzipCompressor.make(...)` and make it implicit."
+)
 trait Compressor[F[_]] {
   def compress: Pipe[F, Byte, Byte]
 }

--- a/core/src/main/scala/de/lhns/fs2/compress/Decompressor.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Decompressor.scala
@@ -2,6 +2,12 @@ package de.lhns.fs2.compress
 
 import fs2.Pipe
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Decompressor[${F}] in scope. Import a default instance, for example `import GzipDecompressor.default._`, or " +
+    "build one with `GzipDecompressor.make(...)` and make it implicit."
+)
 trait Decompressor[F[_]] {
   def decompress: Pipe[F, Byte, Byte]
 }

--- a/core/src/main/scala/de/lhns/fs2/compress/Unarchiver.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Unarchiver.scala
@@ -4,6 +4,12 @@ import cats.effect.{Async, Ref}
 import cats.syntax.all._
 import fs2.{Pipe, Stream}
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Unarchiver[${F}, ${Size}, ${Underlying}] in scope. Import a default instance, for example `import ZipUnarchiver.default._`, "
+    + "or build one with `ZipUnarchiver.make(...)` and make it implicit."
+)
 trait Unarchiver[F[_], Size[A] <: Option[A], Underlying] {
   def unarchive: Pipe[F, Byte, (ArchiveEntry[Size, Underlying], Stream[F, Byte])]
 }

--- a/docs/adr/0022-default-instances-in-a-default-object.md
+++ b/docs/adr/0022-default-instances-in-a-default-object.md
@@ -1,0 +1,113 @@
+# 22. Ship default instances in a `default` object per companion
+
+Date: 2026-08-25
+
+## Status
+
+Proposed
+
+## Context
+
+ADR 0005 made instances something the caller summons implicitly, and recorded the cost in its
+own Consequences: "Instances must be brought into implicit scope by the caller, which is more
+ceremony for someone who just wants to compress one stream."
+
+A contributor proposed closing that gap with convenience methods on every companion —
+`GzipCompressor.compress[F]()` instead of `GzipCompressor.make(...).compress`. The maintainer
+was unconvinced: it runs opposite to the type-class direction fs2 took, every companion needs
+one, and it mostly shortens `make`. Measured, it saves about seven characters and still needs
+the explicit `[IO]`. He counter-proposed importable default instances instead. The discussion
+stopped there, unresolved, for two years.
+
+The counter-proposal is the better fit, because it helps in the case the library actually
+documents: the README's examples pass an instance *implicitly into a polymorphic function*,
+which an import satisfies and a `compress[F]()` helper does not.
+
+## Decision
+
+Each companion gains a nested `object default` holding an implicit instance built from `make()`
+with every argument left alone:
+
+```scala
+object GzipCompressor {
+  def apply[F[_]](implicit instance: GzipCompressor[F]): GzipCompressor[F] = instance
+  def make[F[_]: Async: Compression](...): GzipCompressor[F] = new GzipCompressor(...)
+
+  object default {
+    implicit def defaultGzipCompressor[F[_]: Async: Compression]: GzipCompressor[F] = make()
+  }
+}
+```
+
+`apply` still summons and `make` still constructs; this sits on top of both and supersedes
+nothing in ADR 0005.
+
+Four choices, each with a reason:
+
+- **The concrete type, not the trait.** `GzipCompressor[F]`, never `Compressor[F]`. The
+  summoner needs the concrete type, and an abstract `Compressor[F]` request is still satisfied
+  by subtyping. Annotating the trait would serve one and break the other.
+- **A nested object, not the companion body.** Implicits placed directly in a companion land in
+  the type's implicit scope, so a summon would never fail and a mis-wired instance would be
+  invisible. The nesting is what makes it opt-in. Moving these into the companion body later
+  would quietly remove the ability to opt out.
+- **`implicit def`, not `given`.** `given` members need `import X.default.given`, which does not
+  cross-compile with 2.12 and 2.13.
+- **Members named `default<ClassName>`.** Not the obvious `gzipCompressor`: that is exactly what
+  a caller names their own instance, and a name collision is the one case where the import wins
+  over a local definition. See the measurements below.
+
+Two codecs do not get a `default`, because a default there would be a silent semantic choice:
+
+- **Snappy** gets `framed`, `basic` and `hadoopCompatible` instead. `mode` is the only required
+  parameter in the library and is required on purpose, since the modes produce incompatible
+  bytes. A default would turn a compile error into a stream that fails only when something
+  tries to read it back.
+- **`ZipArchiver.default` is DEFLATED only.** STORED needs the uncompressed size of every entry
+  up front, so it is not something to arrive at by importing a thing called `default`;
+  `makeStored` stays an explicit call. It is also broken independently, never setting CRC or
+  compressed size.
+
+## Considered options
+
+- **Convenience methods on the companion**, as originally proposed. Rejected: it saves very
+  little, adds a parallel API beside the summoner rather than composing with it, and multiplies
+  where a companion has several factories (`archiveDeflated`, `archiveStored`).
+- **Implicits directly in the companion body.** Rejected: always-on, not opt-out.
+- **`given` definitions.** Rejected: does not cross-compile.
+- **Nothing.** Defensible — the ceremony is one line — but the question deserved an answer
+  rather than a third year open.
+
+## Consequences
+
+- One import replaces one `implicit val`, and the summoner keeps working unchanged.
+- **The caching rationale does not hold.** Default objects were attractive partly because they
+  "would make it possible to cache the instances". They do not: every class captures its
+  `Async[F]` evidence as a constructor field, so an instance is tied to one `F` and one evidence
+  value, and no `val` can abstract over `F[_]`. These are `implicit def`s that allocate per
+  summon. That cost is negligible — a stateless object of a few fields, at wiring time, beside
+  a pipe that allocates 64 KiB chunks — but the change rests on ergonomics alone.
+- **Mixing an import with your own instance behaves differently per compiler.** Measured, not
+  assumed: with distinct names, Scala 2.13 and 3 prefer the local definition, while **2.12
+  reports an ambiguity error**. A caller who configures a codec should drop the import. The
+  README says so.
+- **A name collision reverses that.** If the imported member and the local instance share a
+  simple name, Scala 3 silently picks the imported default and the local settings are lost.
+  This is why the members are `defaultGzipCompressor` rather than `gzipCompressor` — the latter
+  is precisely what callers write, including this repo's own test suites.
+- `default` does not remove constraints, only ceremony. Gzip still needs a `Compression[F]`, and
+  on Scala.js that means `import fs2.io.compression._`, since fs2 provides no instance there
+  otherwise. The flagship codec of the README is the one where the import alone is not enough.
+- Nineteen companions, 17 `default` objects and 5 mode objects, each a copy of the same four
+  lines with no shared abstraction possible, since every `make` has a different signature. That
+  is the boilerplate the maintainer objected to in 2024; it is bounded and mechanical.
+- The contributor checklist in ADR 0014 gains a step: a new codec ships a `default` object, or
+  mode-named ones where a default would be a guess. ADR 0014 is left as it stands.
+- `@implicitNotFound` on the four core traits now names both ways to get an instance, since the
+  default message mentions neither.
+
+## References
+
+- PR #154, by Jakob Merrild, and the discussion on it
+- ADR 0005 for the summoner convention this builds on, ADR 0014 for the checklist it extends
+- `core/src/main/scala/de/lhns/fs2/compress/{Compressor,Decompressor,Archiver,Unarchiver}.scala`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ supersedes it.
 | [0019](0019-share-the-output-stream-plumbing.md) | Share the `readOutputStream` plumbing in `OutputStreams` | Accepted |
 | [0020](0020-assert-cancellation-by-counting-not-timing.md) | Assert cancellation by counting bytes, not by elapsed time | Accepted |
 | [0021](0021-skipping-entries-and-stale-reads.md) | Let entries be skipped, and fail when reading data the archive has passed | Proposed |
+| [0022](0022-default-instances-in-a-default-object.md) | Ship default instances in a `default` object per companion | Proposed |
 
 ## Threads worth following
 
@@ -52,6 +53,10 @@ expressed.
 is where every later difficulty comes from: 0018 for cancellation, 0019 for the shared
 plumbing that fixed it in one place, 0020 for how it is tested, and 0021 for what happens
 when a consumer skips an entry.
+
+**How an instance reaches the caller.** 0004 made each operation a trait, 0005 made instances
+something you summon implicitly rather than construct at the call site, and 0022 closes the
+ceremony that left behind by letting you import a default one.
 
 **When to add a module rather than change one.** 0002 established one artifact per codec,
 0007 and 0015 both applied it by adding a second implementation of a format rather than

--- a/gzip/src/main/scala/de/lhns/fs2/compress/Gzip.scala
+++ b/gzip/src/main/scala/de/lhns/fs2/compress/Gzip.scala
@@ -22,6 +22,16 @@ object GzipCompressor {
       chunkSize: Int = Defaults.defaultChunkSize
   ): GzipCompressor[F] =
     new GzipCompressor(deflateLevel, deflateStrategy, chunkSize)
+
+  /** A GzipCompressor built with all defaults, to be imported where an instance is needed:
+    * `import GzipCompressor.default._`
+    *
+    * Gzip also needs a `Compression[F]`, which `import fs2.io.compression._` provides. That import is required on
+    * Scala.js, where fs2 offers no instance otherwise.
+    */
+  object default {
+    implicit def defaultGzipCompressor[F[_]: Async: Compression]: GzipCompressor[F] = make()
+  }
 }
 
 class GzipDecompressor[F[_]: Async: Compression] private (chunkSize: Int) extends Decompressor[F] {
@@ -34,4 +44,13 @@ object GzipDecompressor {
 
   def make[F[_]: Async: Compression](chunkSize: Int = Defaults.defaultChunkSize): GzipDecompressor[F] =
     new GzipDecompressor(chunkSize)
+
+  /** A GzipDecompressor built with all defaults, to be imported where an instance is needed:
+    * `import GzipDecompressor.default._`
+    *
+    * Gzip also needs a `Compression[F]`, which `import fs2.io.compression._` provides.
+    */
+  object default {
+    implicit def defaultGzipDecompressor[F[_]: Async: Compression]: GzipDecompressor[F] = make()
+  }
 }

--- a/gzip/src/test/scalajvm/de/lhns/fs2/compress/GzipDefaultInstanceSuite.scala
+++ b/gzip/src/test/scalajvm/de/lhns/fs2/compress/GzipDefaultInstanceSuite.scala
@@ -1,0 +1,38 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.io.compression._
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class GzipDefaultInstanceSuite extends CatsEffectSuite {
+  import GzipCompressor.default._
+  import GzipDecompressor.default._
+
+  test("gzip round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(GzipCompressor[IO].compress)
+        .through(GzipDecompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+
+  test("a default instance satisfies an abstract Compressor request") {
+    def compressWith[F[_]](stream: Stream[F, Byte])(implicit compressor: Compressor[F]): Stream[F, Byte] =
+      stream.through(compressor.compress)
+
+    compressWith(Stream.chunk[IO, Byte](Chunk.array("hello".getBytes))).compile.drain.map(_ => ())
+  }
+}

--- a/lz4/src/main/scala/de/lhns/fs2/compress/Lz4Compressor.scala
+++ b/lz4/src/main/scala/de/lhns/fs2/compress/Lz4Compressor.scala
@@ -21,6 +21,13 @@ object Lz4Compressor {
       chunkSize: Int = Defaults.defaultChunkSize
   ): Lz4Compressor[F] =
     new Lz4Compressor(chunkSize)
+
+  /** A Lz4Compressor built with all defaults, to be imported where an instance is needed:
+    * `import Lz4Compressor.default._`
+    */
+  object default {
+    implicit def defaultLz4Compressor[F[_]: Async]: Lz4Compressor[F] = make()
+  }
 }
 
 class Lz4Decompressor[F[_]: Async] private (chunkSize: Int) extends Decompressor[F] {
@@ -42,4 +49,11 @@ object Lz4Decompressor {
 
   def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): Lz4Decompressor[F] =
     new Lz4Decompressor(chunkSize)
+
+  /** A Lz4Decompressor built with all defaults, to be imported where an instance is needed:
+    * `import Lz4Decompressor.default._`
+    */
+  object default {
+    implicit def defaultLz4Decompressor[F[_]: Async]: Lz4Decompressor[F] = make()
+  }
 }

--- a/lz4/src/test/scala/de/lhns/fs2/compress/Lz4DefaultInstanceSuite.scala
+++ b/lz4/src/test/scala/de/lhns/fs2/compress/Lz4DefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class Lz4DefaultInstanceSuite extends CatsEffectSuite {
+  import Lz4Compressor.default._
+  import Lz4Decompressor.default._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(Lz4Compressor[IO].compress)
+        .through(Lz4Decompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/snappy/src/main/scala/de/lhns/fs2/compress/SnappyCompressor.scala
+++ b/snappy/src/main/scala/de/lhns/fs2/compress/SnappyCompressor.scala
@@ -58,6 +58,26 @@ object SnappyCompressor {
       chunkSize: Int = Defaults.defaultChunkSize,
       mode: WriteMode
   ): SnappyCompressor[F] = new SnappyCompressor(chunkSize, mode)
+
+  // These are named after the modes rather than offering a `default`, because the modes do not produce interchangeable
+  // bytes. Picking one for the caller would turn a compile error into a stream that only fails when something tries to
+  // read it back.
+
+  /** The Snappy framing format. `import SnappyCompressor.framed._` */
+  object framed {
+    implicit def framedSnappyCompressor[F[_]: Async]: SnappyCompressor[F] = make(mode = WriteMode.Framed())
+  }
+
+  /** snappy-java's own block format. `import SnappyCompressor.basic._` */
+  object basic {
+    implicit def basicSnappyCompressor[F[_]: Async]: SnappyCompressor[F] = make(mode = WriteMode.Basic())
+  }
+
+  /** The block format without a stream header, for Hadoop. `import SnappyCompressor.hadoopCompatible._` */
+  object hadoopCompatible {
+    implicit def hadoopCompatibleSnappyCompressor[F[_]: Async]: SnappyCompressor[F] =
+      make(mode = WriteMode.HadoopCompatible())
+  }
 }
 
 class SnappyDecompressor[F[_]: Async] private (chunkSize: Int, decompressionType: SnappyDecompressor.ReadMode)
@@ -103,4 +123,16 @@ object SnappyDecompressor {
 
   def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize, mode: ReadMode): SnappyDecompressor[F] =
     new SnappyDecompressor(chunkSize, mode)
+
+  // Named after the modes for the same reason as SnappyCompressor: they read different formats.
+
+  /** The Snappy framing format. `import SnappyDecompressor.framed._` */
+  object framed {
+    implicit def framedSnappyDecompressor[F[_]: Async]: SnappyDecompressor[F] = make(mode = ReadMode.Framed())
+  }
+
+  /** snappy-java's own block format. `import SnappyDecompressor.basic._` */
+  object basic {
+    implicit def basicSnappyDecompressor[F[_]: Async]: SnappyDecompressor[F] = make(mode = ReadMode.Basic())
+  }
 }

--- a/snappy/src/test/scala/de/lhns/fs2/compress/SnappyDefaultInstanceSuite.scala
+++ b/snappy/src/test/scala/de/lhns/fs2/compress/SnappyDefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class SnappyDefaultInstanceSuite extends CatsEffectSuite {
+  import SnappyCompressor.framed._
+  import SnappyDecompressor.framed._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(SnappyCompressor[IO].compress)
+        .through(SnappyDecompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/tar/src/main/scala/de/lhns/fs2/compress/Tar.scala
+++ b/tar/src/main/scala/de/lhns/fs2/compress/Tar.scala
@@ -84,6 +84,12 @@ object TarArchiver {
 
   def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): TarArchiver[F] =
     new TarArchiver(chunkSize)
+
+  /** A TarArchiver built with all defaults, to be imported where an instance is needed: `import TarArchiver.default._`
+    */
+  object default {
+    implicit def defaultTarArchiver[F[_]: Async]: TarArchiver[F] = make()
+  }
 }
 
 class TarUnarchiver[F[_]: Async] private (chunkSize: Int) extends Unarchiver[F, Option, TarArchiveEntry] {
@@ -114,4 +120,11 @@ object TarUnarchiver {
 
   def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): TarUnarchiver[F] =
     new TarUnarchiver(chunkSize)
+
+  /** A TarUnarchiver built with all defaults, to be imported where an instance is needed:
+    * `import TarUnarchiver.default._`
+    */
+  object default {
+    implicit def defaultTarUnarchiver[F[_]: Async]: TarUnarchiver[F] = make()
+  }
 }

--- a/tar/src/test/scala/de/lhns/fs2/compress/TarDefaultInstanceSuite.scala
+++ b/tar/src/test/scala/de/lhns/fs2/compress/TarDefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class TarDefaultInstanceSuite extends CatsEffectSuite {
+  import TarArchiver.default._
+  import TarUnarchiver.default._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(ArchiveSingleFileCompressor.forName(TarArchiver[IO], "test", expected.length.toLong).compress)
+        .through(ArchiveSingleFileDecompressor(TarUnarchiver[IO]).decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
+++ b/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
@@ -97,6 +97,15 @@ object ZipArchiver {
     */
   def makeStored[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): ZipArchiver[F, Some] =
     make[F, Some](ZipOutputStream.STORED, chunkSize)
+
+  /** The DEFLATED archiver, to be imported where an instance is needed: `import ZipArchiver.default._`
+    *
+    * There is deliberately no default for STORED. That method needs the uncompressed size of every entry up front, so
+    * it is a choice a caller has to make rather than something to arrive at by importing; use `makeStored` for it.
+    */
+  object default {
+    implicit def defaultZipArchiver[F[_]: Async]: ZipArchiver[F, Option] = makeDeflated()
+  }
 }
 
 class ZipUnarchiver[F[_]: Async] private (chunkSize: Int) extends Unarchiver[F, Option, ZipEntry] {
@@ -130,4 +139,11 @@ object ZipUnarchiver {
 
   def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): ZipUnarchiver[F] =
     new ZipUnarchiver(chunkSize)
+
+  /** A ZipUnarchiver built with all defaults, to be imported where an instance is needed:
+    * `import ZipUnarchiver.default._`
+    */
+  object default {
+    implicit def defaultZipUnarchiver[F[_]: Async]: ZipUnarchiver[F] = make()
+  }
 }

--- a/zip/src/test/scala/de/lhns/fs2/compress/ZipDefaultInstanceSuite.scala
+++ b/zip/src/test/scala/de/lhns/fs2/compress/ZipDefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class ZipDefaultInstanceSuite extends CatsEffectSuite {
+  import ZipArchiver.default._
+  import ZipUnarchiver.default._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(ArchiveSingleFileCompressor.forName(ZipArchiver[IO, Option], "test").compress)
+        .through(ArchiveSingleFileDecompressor(ZipUnarchiver[IO]).decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/zip4j/src/main/scala/de/lhns/fs2/compress/Zip4J.scala
+++ b/zip4j/src/main/scala/de/lhns/fs2/compress/Zip4J.scala
@@ -96,6 +96,15 @@ object Zip4JArchiver {
       chunkSize: Int = Defaults.defaultChunkSize
   ): Zip4JArchiver[F] =
     new Zip4JArchiver(password, chunkSize)
+
+  /** A Zip4JArchiver that writes without a password, to be imported where an instance is needed:
+    * `import Zip4JArchiver.default._`
+    *
+    * For an encrypted archive use `make(password = ...)`.
+    */
+  object default {
+    implicit def defaultZip4JArchiver[F[_]: Async]: Zip4JArchiver[F] = make()
+  }
 }
 
 class Zip4JUnarchiver[F[_]: Async] private (password: => Option[String], chunkSize: Int)
@@ -136,4 +145,13 @@ object Zip4JUnarchiver {
       chunkSize: Int = Defaults.defaultChunkSize
   ): Zip4JUnarchiver[F] =
     new Zip4JUnarchiver(password, chunkSize)
+
+  /** A Zip4JUnarchiver that reads unencrypted archives, to be imported where an instance is needed:
+    * `import Zip4JUnarchiver.default._`
+    *
+    * To read an encrypted archive use `make(password = ...)`.
+    */
+  object default {
+    implicit def defaultZip4JUnarchiver[F[_]: Async]: Zip4JUnarchiver[F] = make()
+  }
 }

--- a/zip4j/src/test/scala/de/lhns/fs2/compress/Zip4JDefaultInstanceSuite.scala
+++ b/zip4j/src/test/scala/de/lhns/fs2/compress/Zip4JDefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class Zip4JDefaultInstanceSuite extends CatsEffectSuite {
+  import Zip4JArchiver.default._
+  import Zip4JUnarchiver.default._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(ArchiveSingleFileCompressor.forName(Zip4JArchiver[IO], "test", expected.length.toLong).compress)
+        .through(ArchiveSingleFileDecompressor(Zip4JUnarchiver[IO]).decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}

--- a/zstd/src/main/scala/de/lhns/fs2/compress/Zstd.scala
+++ b/zstd/src/main/scala/de/lhns/fs2/compress/Zstd.scala
@@ -27,6 +27,13 @@ object ZstdCompressor {
       chunkSize: Int = Defaults.defaultChunkSize
   ): ZstdCompressor[F] =
     new ZstdCompressor(level, workers, chunkSize)
+
+  /** A ZstdCompressor built with all defaults, to be imported where an instance is needed:
+    * `import ZstdCompressor.default._`
+    */
+  object default {
+    implicit def defaultZstdCompressor[F[_]: Async]: ZstdCompressor[F] = make()
+  }
 }
 
 class ZstdDecompressor[F[_]: Async] private (chunkSize: Int) extends Decompressor[F] {
@@ -48,4 +55,11 @@ object ZstdDecompressor {
 
   def make[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): ZstdDecompressor[F] =
     new ZstdDecompressor(chunkSize)
+
+  /** A ZstdDecompressor built with all defaults, to be imported where an instance is needed:
+    * `import ZstdDecompressor.default._`
+    */
+  object default {
+    implicit def defaultZstdDecompressor[F[_]: Async]: ZstdDecompressor[F] = make()
+  }
 }

--- a/zstd/src/test/scala/de/lhns/fs2/compress/ZstdDefaultInstanceSuite.scala
+++ b/zstd/src/test/scala/de/lhns/fs2/compress/ZstdDefaultInstanceSuite.scala
@@ -1,0 +1,30 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.util
+
+/** The default instances are usable by importing them, with no `implicit val` at the call site. */
+class ZstdDefaultInstanceSuite extends CatsEffectSuite {
+  import ZstdCompressor.default._
+  import ZstdDecompressor.default._
+
+  test("round trip through the default instances") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(1024)
+      obtained <- Stream
+        .chunk(Chunk.array(expected))
+        .through(ZstdCompressor[IO].compress)
+        .through(ZstdDecompressor[IO].decompress)
+        .chunkAll
+        .compile
+        .lastOrError
+        .map(_.toArray)
+      _ = assert(util.Arrays.equals(expected, obtained))
+    } yield ()
+  }
+}


### PR DESCRIPTION
Answers #154, two years on, with @jakobmerrild's second idea rather than his first. Please close #154 once this lands — including the question in his last comment, which never got a reply: yes, the suggestion was to move the convenience into an importable object, and this is what that looks like.

Every codec companion gains a nested `default` object holding an instance built from `make()` with nothing configured:

```scala
import GzipCompressor.default._

GzipCompressor[IO].compress
```

`apply` still summons and `make` still constructs. This sits on top of both and supersedes nothing.

## Why not the convenience methods as originally proposed

`GzipCompressor.make[IO]().compress` → `GzipCompressor.compress[IO]()` saves about seven characters and still needs the explicit `[IO]`. More to the point, it does not help in the case the README actually documents, where the instance is passed *implicitly into a polymorphic function* — an import satisfies that, a helper method does not. It also multiplies where a companion has several factories, needing `archiveDeflated` and `archiveStored`.

Jakob's follow-up question in the PR description — whether a parameterless `GzipCompressor.compress` would be nicer — was the right instinct, and this is the same instinct taken one step further: the parameterless thing is the instance, and you import it.

## Two carve-outs

**Snappy gets `framed`, `basic` and `hadoopCompatible`, not `default`.** `mode` is the only required parameter in the library and it is required deliberately, because the modes produce incompatible bytes. A default would turn a compile error into a stream that fails only when something tries to read it back.

**`ZipArchiver.default` is DEFLATED only.** STORED needs the uncompressed size of every entry up front, so it is not something to reach by importing `default`; `makeStored` stays explicit. (It is also broken independently — it never sets CRC or compressed size.)

## What the spike found, which changed the design

I verified the implicit-resolution behaviour on 2.12, 2.13 and 3 before writing 22 objects, and two results changed decisions:

**Members are named `defaultGzipCompressor`, not `gzipCompressor`.** If the imported member and a local instance share a simple name, Scala 3 silently prefers the *import* and the local settings are lost. The obvious house-style name is exactly what a caller writes for their own instance — this repo's own `GzipRoundTripSuite` uses `implicit val gzipCompressor` — so that name is the one to avoid.

**Mixing an import with your own instance is compiler-dependent.** With distinct names, 2.13 and 3 prefer the local definition; **2.12 reports an ambiguity error**. So configuring a codec means dropping the import, and the README says so.

The README also now says to annotate a configured instance with the **concrete** type. An instance typed as `Compressor[IO]` loses to a `default` import without a word, because the import is more specific — that one is a genuine footgun and the README previously taught the pattern that triggers it.

## Also in here

- `@implicitNotFound` on the four core traits, since the default message names neither `default` nor `make`.
- ADR 0022, Proposed, recording the carve-outs, the naming finding, and one correction: default objects were partly attractive because they "would make it possible to cache the instances". **They do not.** Every class captures its `Async[F]` evidence as a constructor field, so an instance is tied to one `F` and no `val` can abstract over `F[_]`. These allocate per summon, which is negligible, but the change rests on ergonomics alone.
- Four pre-existing errors in the README examples, since anyone copying them into a `default` example would inherit them: a missing `Underlying` parameter, a `Decompress` typo, a `decompressFile` that read `toCompress`, and two functions missing the `Async` bound. The examples are not compiled — no mdoc — which is how they survived. Worth its own issue.

## Checks

9 new default-instance suites, one per module, each round-tripping through imported instances; 35 suites green on the JVM and green on Scala.js for `core` and `gzip`; full cross-version matrix. Existing suites are deliberately left declaring their own instances — `ZipRoundTripSuite` holds both `[IO, Some]` and `[IO, Option]`, and `SnappyRoundTripSuite` parameterises over the modes, which is exactly what `default` cannot express.
