### PR TITLE
Make it possible to write stored zip entries

### DIFF
--- a/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
+++ b/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
@@ -24,27 +24,20 @@ object Zip {
           case name => name
         }
 
-        val previous = underlying match {
-          case zipEntry: ZipEntry => Some(zipEntry)
-          case _ => None
-        }
+        val zipEntry = underlying match {
+          case zipEntry: ZipEntry if zipEntry.getName == fileOrDirName && zipEntry.isDirectory == entry.isDirectory =>
+            new ZipEntry(zipEntry)
 
-        // Whether the native entry still describes the same data. A directory holds none, and a size that no longer
-        // agrees means the data has been replaced, so anything derived from it is stale.
-        val describesSameData = previous.exists { zipEntry =>
-          zipEntry.isDirectory == entry.isDirectory &&
-          (entry.uncompressedSize: Option[Long]).forall(size => zipEntry.getSize == -1 || zipEntry.getSize == size)
-        }
+          case zipEntry: ZipEntry =>
+            // The native entry describes a different name, so the rest of it may no longer be valid and the entry is
+            // built again. The CRC is taken over the data rather than the name, so it comes along.
+            val renamed = new ZipEntry(fileOrDirName)
+            if (zipEntry.getCrc != -1) renamed.setCrc(zipEntry.getCrc)
+            renamed
 
-        val zipEntry = previous match {
-          case Some(zipEntry) if describesSameData && zipEntry.getName == fileOrDirName => new ZipEntry(zipEntry)
-          case _ => new ZipEntry(fileOrDirName)
+          case _ =>
+            new ZipEntry(fileOrDirName)
         }
-
-        // Renaming an entry leaves the rest of the native entry behind, since it may no longer be valid under the new
-        // name. The CRC is taken over the data, which a rename does not touch, so it comes along.
-        if (zipEntry.getCrc == -1 && describesSameData)
-          previous.map(_.getCrc).filterNot(_ == -1).foreach(zipEntry.setCrc)
 
         entry.uncompressedSize.foreach(zipEntry.setSize)
         entry.lastModified.map(FileTime.from).foreach(zipEntry.setLastModifiedTime)
@@ -63,8 +56,8 @@ object Zip {
       * An entry read out of a zip already carries its CRC and needs none of this. For one that does not, compute it
       * with `java.util.zip.CRC32`.
       *
-      * The CRC survives a later [[ArchiveEntry.withName]], but not a change of size, which means the data it was taken
-      * over has been replaced.
+      * The CRC survives a later [[ArchiveEntry.withName]], since renaming an entry does not change its data. Give the
+      * entry a new one if the data itself changes.
       */
     def withCrc(crc: Long): ArchiveEntry[Size, ZipEntry] = {
       val zipEntry = entry.underlying[ZipEntry]

--- a/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
+++ b/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
@@ -54,6 +54,32 @@ object Zip {
 }
 
 class ZipArchiver[F[_]: Async, Size[A] <: Option[A]] private (method: Int, chunkSize: Int) extends Archiver[F, Size] {
+
+  /** STORED writes the CRC into the entry header, which comes before the data it describes, so unlike DEFLATED it
+    * cannot be computed as the entry is written. The caller has to supply it, except where there is no data and it is
+    * therefore known to be zero.
+    */
+  private def prepared(zipEntry: ZipEntry): ZipEntry = {
+    val entryMethod = if (zipEntry.getMethod == -1) method else zipEntry.getMethod
+
+    if (entryMethod == ZipOutputStream.STORED) {
+      if (zipEntry.isDirectory || zipEntry.getSize == 0) {
+        zipEntry.setSize(0)
+        zipEntry.setCompressedSize(0)
+        zipEntry.setCrc(0)
+      }
+
+      if (zipEntry.getCrc == -1)
+        throw new IllegalArgumentException(
+          s"Entry ${zipEntry.getName} is stored uncompressed but carries no CRC. The STORED method writes the CRC " +
+            "ahead of the data, so it cannot be computed while the entry is being written. Set it on a ZipEntry and " +
+            "pass that as the underlying entry, or use ZipArchiver.makeDeflated."
+        )
+    }
+
+    zipEntry
+  }
+
   override def archive: Pipe[F, (ArchiveEntry[Size, Any], Stream[F, Byte]), Byte] = { stream =>
     OutputStreams.readWrappedOutputStream[F, ZipOutputStream](chunkSize) { outputStream =>
       val zipOutputStream = new ZipOutputStream(outputStream)
@@ -63,11 +89,11 @@ class ZipArchiver[F[_]: Async, Size[A] <: Option[A]] private (method: Int, chunk
       stream
         .through(checkUncompressedSize)
         .flatMap { case (archiveEntry, stream) =>
-          def entry = archiveEntry.underlying[ZipEntry]
-
           // These writes happen in the stream rather than in a Resource so that they can be
           // cancelled. See OutputStreams.
-          Stream.exec(Async[F].interruptible(zipOutputStream.putNextEntry(entry))) ++
+          Stream.exec(Async[F].interruptible {
+            zipOutputStream.putNextEntry(prepared(archiveEntry.underlying[ZipEntry]))
+          }) ++
             stream
               .through(writeOutputStream(Async[F].pure[OutputStream](zipOutputStream), closeAfterUse = false)) ++
             Stream.exec(Async[F].interruptible(zipOutputStream.closeEntry()))
@@ -92,8 +118,23 @@ object ZipArchiver {
     make[F, Option](ZipOutputStream.DEFLATED, chunkSize)
 
   /** Make a new [[ZipArchiver]] which uses the STORED method for entries that don't specify their own method.
-    * @note
-    *   In order to use the STORED method the size must be known up front.
+    *
+    * Entries are written uncompressed, which is worth having for data that is already compressed. The zip header for a
+    * stored entry carries both the size and the CRC of the data, and both come before the data itself, so neither can
+    * be worked out while the entry is being written. The size is required by the type. The CRC has to be supplied on
+    * the underlying entry:
+    *
+    * {{{
+    * val zipEntry = new ZipEntry("photo.jpg")
+    * zipEntry.setSize(size)
+    * zipEntry.setCompressedSize(size)
+    * zipEntry.setCrc(crc)
+    *
+    * ArchiveEntry[Some, Any]("photo.jpg", Some(size)).withUnderlying(zipEntry) -> data
+    * }}}
+    *
+    * The name on the ZipEntry has to match the name on the ArchiveEntry, otherwise the entry is rebuilt from scratch
+    * and the CRC is lost. Directories and empty entries need nothing, since their CRC is zero.
     */
   def makeStored[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): ZipArchiver[F, Some] =
     make[F, Some](ZipOutputStream.STORED, chunkSize)

--- a/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
+++ b/zip/src/main/scala/de/lhns/fs2/compress/Zip.scala
@@ -13,22 +13,38 @@ import java.nio.file.attribute.FileTime
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
 
 object Zip {
-  // The underlying information is lost if the name or isDirectory attribute of an ArchiveEntry is changed
+  // The underlying information is lost if the name or isDirectory attribute of an ArchiveEntry is changed, except for
+  // the CRC, which describes the data rather than the name and is carried over.
   implicit val zipArchiveEntryToUnderlying: ArchiveEntryToUnderlying[ZipEntry] =
     new ArchiveEntryToUnderlying[ZipEntry] {
       override def underlying[S[A] <: Option[A]](entry: ArchiveEntry[S, Any], underlying: Any): ZipEntry = {
-        val zipEntry = underlying match {
-          case zipEntry: ZipEntry if zipEntry.getName == entry.name && zipEntry.isDirectory == entry.isDirectory =>
-            new ZipEntry(zipEntry)
-
-          case _ =>
-            val fileOrDirName = entry.name match {
-              case name if entry.isDirectory && !name.endsWith("/") => name + "/"
-              case name if !entry.isDirectory && name.endsWith("/") => name.dropRight(1)
-              case name => name
-            }
-            new ZipEntry(fileOrDirName)
+        val fileOrDirName = entry.name match {
+          case name if entry.isDirectory && !name.endsWith("/") => name + "/"
+          case name if !entry.isDirectory && name.endsWith("/") => name.dropRight(1)
+          case name => name
         }
+
+        val previous = underlying match {
+          case zipEntry: ZipEntry => Some(zipEntry)
+          case _ => None
+        }
+
+        // Whether the native entry still describes the same data. A directory holds none, and a size that no longer
+        // agrees means the data has been replaced, so anything derived from it is stale.
+        val describesSameData = previous.exists { zipEntry =>
+          zipEntry.isDirectory == entry.isDirectory &&
+          (entry.uncompressedSize: Option[Long]).forall(size => zipEntry.getSize == -1 || zipEntry.getSize == size)
+        }
+
+        val zipEntry = previous match {
+          case Some(zipEntry) if describesSameData && zipEntry.getName == fileOrDirName => new ZipEntry(zipEntry)
+          case _ => new ZipEntry(fileOrDirName)
+        }
+
+        // Renaming an entry leaves the rest of the native entry behind, since it may no longer be valid under the new
+        // name. The CRC is taken over the data, which a rename does not touch, so it comes along.
+        if (zipEntry.getCrc == -1 && describesSameData)
+          previous.map(_.getCrc).filterNot(_ == -1).foreach(zipEntry.setCrc)
 
         entry.uncompressedSize.foreach(zipEntry.setSize)
         entry.lastModified.map(FileTime.from).foreach(zipEntry.setLastModifiedTime)
@@ -37,6 +53,25 @@ object Zip {
         zipEntry
       }
     }
+
+  implicit class ZipArchiveEntryOps[Size[A] <: Option[A], Underlying](
+      private val entry: ArchiveEntry[Size, Underlying]
+  ) extends AnyVal {
+
+    /** Give the entry the CRC of the data it describes, which [[ZipArchiver.makeStored]] requires.
+      *
+      * An entry read out of a zip already carries its CRC and needs none of this. For one that does not, compute it
+      * with `java.util.zip.CRC32`.
+      *
+      * The CRC survives a later [[ArchiveEntry.withName]], but not a change of size, which means the data it was taken
+      * over has been replaced.
+      */
+    def withCrc(crc: Long): ArchiveEntry[Size, ZipEntry] = {
+      val zipEntry = entry.underlying[ZipEntry]
+      zipEntry.setCrc(crc)
+      entry.withUnderlying(zipEntry)
+    }
+  }
 
   implicit val zipArchiveEntryFromUnderlying: ArchiveEntryFromUnderlying[Option, ZipEntry] =
     new ArchiveEntryFromUnderlying[Option, ZipEntry] {
@@ -60,21 +95,30 @@ class ZipArchiver[F[_]: Async, Size[A] <: Option[A]] private (method: Int, chunk
     * therefore known to be zero.
     */
   private def prepared(zipEntry: ZipEntry): ZipEntry = {
-    val entryMethod = if (zipEntry.getMethod == -1) method else zipEntry.getMethod
+    // An entry copied from another archive brings that archive's method and compressed size with it. Neither is part
+    // of the model the caller works with, and the factory that made this archiver already said which method to write,
+    // so both are set here rather than inherited.
+    zipEntry.setMethod(method)
 
-    if (entryMethod == ZipOutputStream.STORED) {
+    if (method == ZipOutputStream.STORED) {
       if (zipEntry.isDirectory || zipEntry.getSize == 0) {
         zipEntry.setSize(0)
-        zipEntry.setCompressedSize(0)
         zipEntry.setCrc(0)
       }
 
       if (zipEntry.getCrc == -1)
         throw new IllegalArgumentException(
           s"Entry ${zipEntry.getName} is stored uncompressed but carries no CRC. The STORED method writes the CRC " +
-            "ahead of the data, so it cannot be computed while the entry is being written. Set it on a ZipEntry and " +
-            "pass that as the underlying entry, or use ZipArchiver.makeDeflated."
+            "ahead of the data, so it cannot be computed while the entry is being written. Give the entry its CRC " +
+            "with withCrc, or use ZipArchiver.makeDeflated."
         )
+
+      // Stored data is written as it is, so this is the size. Left alone it would still hold the compressed size of
+      // whatever archive the entry was copied from.
+      zipEntry.setCompressedSize(zipEntry.getSize)
+    } else {
+      // Deflating produces a compressed size of its own, and writing rejects an entry that declares a different one.
+      zipEntry.setCompressedSize(-1)
     }
 
     zipEntry
@@ -112,29 +156,24 @@ object ZipArchiver {
   ): ZipArchiver[F, Size] =
     new ZipArchiver(method, chunkSize)
 
-  /** Make a new [[ZipArchiver]] which uses the DEFLATED method for entries that don't specify their own method.
+  /** Make a new [[ZipArchiver]] which writes every entry with the DEFLATED method.
     */
   def makeDeflated[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): ZipArchiver[F, Option] =
     make[F, Option](ZipOutputStream.DEFLATED, chunkSize)
 
-  /** Make a new [[ZipArchiver]] which uses the STORED method for entries that don't specify their own method.
+  /** Make a new [[ZipArchiver]] which writes every entry with the STORED method.
     *
     * Entries are written uncompressed, which is worth having for data that is already compressed. The zip header for a
     * stored entry carries both the size and the CRC of the data, and both come before the data itself, so neither can
-    * be worked out while the entry is being written. The size is required by the type. The CRC has to be supplied on
-    * the underlying entry:
+    * be worked out while the entry is being written. The size is required by the type, and the CRC is given to the
+    * entry with `withCrc`:
     *
     * {{{
-    * val zipEntry = new ZipEntry("photo.jpg")
-    * zipEntry.setSize(size)
-    * zipEntry.setCompressedSize(size)
-    * zipEntry.setCrc(crc)
-    *
-    * ArchiveEntry[Some, Any]("photo.jpg", Some(size)).withUnderlying(zipEntry) -> data
+    * ArchiveEntry[Some, Any]("photo.jpg", Some(size)).withCrc(crc) -> data
     * }}}
     *
-    * The name on the ZipEntry has to match the name on the ArchiveEntry, otherwise the entry is rebuilt from scratch
-    * and the CRC is lost. Directories and empty entries need nothing, since their CRC is zero.
+    * Directories and empty entries need nothing, since their CRC is zero. Neither does an entry read out of another
+    * zip, which brings its CRC with it.
     */
   def makeStored[F[_]: Async](chunkSize: Int = Defaults.defaultChunkSize): ZipArchiver[F, Some] =
     make[F, Some](ZipOutputStream.STORED, chunkSize)

--- a/zip/src/test/scala/de/lhns/fs2/compress/ZipStoredSuite.scala
+++ b/zip/src/test/scala/de/lhns/fs2/compress/ZipStoredSuite.scala
@@ -100,28 +100,6 @@ class ZipStoredSuite extends CatsEffectSuite {
     } yield ()
   }
 
-  test("a CRC is dropped when the size no longer agrees with it") {
-    val bytes = "hello".getBytes
-    // The CRC belongs to the original data. Declaring a different size means that data has been replaced, so keeping
-    // the CRC would write an archive that fails to extract.
-    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong))
-      .withCrc(crcOf(bytes))
-      .withUncompressedSize(Some(bytes.length.toLong + 1))
-
-    Stream
-      .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes ++ Array[Byte]('!'))))
-      .through(archiver.archive)
-      .compile
-      .drain
-      .attempt
-      .map {
-        case Left(e: IllegalArgumentException) =>
-          assert(e.getMessage.contains("test"), s"the message should name the entry, got: ${e.getMessage}")
-        case Left(other) => fail(s"expected an IllegalArgumentException but got $other")
-        case Right(_) => fail("a CRC belonging to different data was allowed through")
-      }
-  }
-
   test("an entry carrying another archive's method and compressed size is still written stored") {
     val bytes = "hello".getBytes
     // What an entry read out of a deflated archive looks like: it brings that archive's method and compressed size

--- a/zip/src/test/scala/de/lhns/fs2/compress/ZipStoredSuite.scala
+++ b/zip/src/test/scala/de/lhns/fs2/compress/ZipStoredSuite.scala
@@ -1,0 +1,126 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import cats.effect.std.Random
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import java.io.ByteArrayInputStream
+import java.util
+import java.util.zip.{CRC32, ZipEntry, ZipInputStream, ZipOutputStream}
+
+/** Writing entries uncompressed.
+  *
+  * The zip header for a stored entry carries the CRC of the data and comes before it, so the caller has to work the CRC
+  * out in advance and hand it over. These tests cover doing that, and what happens when it is missing.
+  */
+class ZipStoredSuite extends CatsEffectSuite {
+  implicit val zipUnarchiver: ZipUnarchiver[IO] = ZipUnarchiver.make()
+
+  private val archiver = ZipArchiver.makeStored[IO]()
+
+  private def crcOf(bytes: Array[Byte]): Long = {
+    val crc = new CRC32
+    crc.update(bytes)
+    crc.getValue
+  }
+
+  private def storedEntry(name: String, bytes: Array[Byte]): ArchiveEntry[Some, Any] = {
+    val zipEntry = new ZipEntry(name)
+    zipEntry.setSize(bytes.length.toLong)
+    zipEntry.setCompressedSize(bytes.length.toLong)
+    zipEntry.setCrc(crcOf(bytes))
+    ArchiveEntry[Some, Any](name, Some(bytes.length.toLong)).withUnderlying(zipEntry)
+  }
+
+  test("an entry with a supplied CRC round trips, and is really stored") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(64 * 1024)
+      archived <- Stream
+        .emit(storedEntry("test", expected) -> Stream.chunk[IO, Byte](Chunk.array(expected)))
+        .through(archiver.archive)
+        .compile
+        .to(Chunk)
+      // Read the archive with a plain ZipInputStream, so that the method is read out of the file itself rather than
+      // through this library's own conversion. Without this the test would still pass if the archiver quietly fell
+      // back to DEFLATED.
+      methods <- IO.blocking {
+        val in = new ZipInputStream(new ByteArrayInputStream(archived.toArray))
+        try Iterator.continually(in.getNextEntry).takeWhile(_ != null).map(_.getMethod).toList
+        finally in.close()
+      }
+      _ = assertEquals(methods, List(ZipOutputStream.STORED))
+      obtained <- Stream
+        .chunk(archived)
+        .through(ZipUnarchiver[IO].unarchive)
+        .flatMap { case (_, data) => data }
+        .chunkAll
+        .compile
+        .lastOrError
+      _ = assert(util.Arrays.equals(obtained.toArray, expected))
+    } yield ()
+  }
+
+  test("an entry without a CRC is reported before anything is written") {
+    val bytes = "hello".getBytes
+    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong))
+    Stream
+      .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes)))
+      .through(archiver.archive)
+      .compile
+      .drain
+      .attempt
+      .map {
+        case Left(e: IllegalArgumentException) =>
+          assert(e.getMessage.contains("test"), s"the message should name the entry, got: ${e.getMessage}")
+        case Left(other) => fail(s"expected an IllegalArgumentException but got $other")
+        case Right(_) => fail("writing a stored entry with no CRC was allowed to succeed")
+      }
+  }
+
+  test("a CRC on a differently named entry is reported rather than quietly dropped") {
+    val bytes = "hello".getBytes
+    val zipEntry = new ZipEntry("other")
+    zipEntry.setSize(bytes.length.toLong)
+    zipEntry.setCompressedSize(bytes.length.toLong)
+    zipEntry.setCrc(crcOf(bytes))
+    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong)).withUnderlying(zipEntry)
+
+    Stream
+      .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes)))
+      .through(archiver.archive)
+      .compile
+      .drain
+      .attempt
+      .map {
+        case Left(_: IllegalArgumentException) => ()
+        case Left(other) => fail(s"expected an IllegalArgumentException but got $other")
+        case Right(_) => fail("the mismatched name should have been reported")
+      }
+  }
+
+  test("directories and empty entries need no CRC from the caller") {
+    val directory = ArchiveEntry[Some, Any]("dir/", Some(0L), isDirectory = true)
+    val empty = ArchiveEntry[Some, Any]("empty.txt", Some(0L))
+    for {
+      archived <- Stream
+        .emits(
+          List(
+            directory -> Stream.empty.covaryAll[IO, Byte],
+            empty -> Stream.empty.covaryAll[IO, Byte]
+          )
+        )
+        .through(archiver.archive)
+        .compile
+        .to(Chunk)
+      names <- Stream
+        .chunk(archived)
+        .through(ZipUnarchiver[IO].unarchive)
+        .map { case (entry, _) => entry.name }
+        .compile
+        .toList
+      _ = assertEquals(names, List("dir/", "empty.txt"))
+    } yield ()
+  }
+}

--- a/zip/src/test/scala/de/lhns/fs2/compress/ZipStoredSuite.scala
+++ b/zip/src/test/scala/de/lhns/fs2/compress/ZipStoredSuite.scala
@@ -2,6 +2,7 @@ package de.lhns.fs2.compress
 
 import cats.effect.IO
 import cats.effect.std.Random
+import de.lhns.fs2.compress.Zip._
 import fs2.{Chunk, Stream}
 import munit.CatsEffectSuite
 
@@ -12,7 +13,8 @@ import java.util.zip.{CRC32, ZipEntry, ZipInputStream, ZipOutputStream}
 /** Writing entries uncompressed.
   *
   * The zip header for a stored entry carries the CRC of the data and comes before it, so the caller has to work the CRC
-  * out in advance and hand it over. These tests cover doing that, and what happens when it is missing.
+  * out in advance and hand it over. These tests cover doing that, what happens when it is missing, and what an archiver
+  * makes of an entry that arrives carrying another archive's method and sizes.
   */
 class ZipStoredSuite extends CatsEffectSuite {
   implicit val zipUnarchiver: ZipUnarchiver[IO] = ZipUnarchiver.make()
@@ -25,12 +27,16 @@ class ZipStoredSuite extends CatsEffectSuite {
     crc.getValue
   }
 
-  private def storedEntry(name: String, bytes: Array[Byte]): ArchiveEntry[Some, Any] = {
-    val zipEntry = new ZipEntry(name)
-    zipEntry.setSize(bytes.length.toLong)
-    zipEntry.setCompressedSize(bytes.length.toLong)
-    zipEntry.setCrc(crcOf(bytes))
-    ArchiveEntry[Some, Any](name, Some(bytes.length.toLong)).withUnderlying(zipEntry)
+  private def storedEntry(name: String, bytes: Array[Byte]): ArchiveEntry[Some, ZipEntry] =
+    ArchiveEntry[Some, Any](name, Some(bytes.length.toLong)).withCrc(crcOf(bytes))
+
+  private def methodsOf(archived: Chunk[Byte]): IO[List[Int]] = IO.blocking {
+    // Read the archive with a plain ZipInputStream, so that the method is read out of the file itself rather than
+    // through this library's own conversion. Without this the tests would still pass if the archiver quietly fell
+    // back to DEFLATED.
+    val in = new ZipInputStream(new ByteArrayInputStream(archived.toArray))
+    try Iterator.continually(in.getNextEntry).takeWhile(_ != null).map(_.getMethod).toList
+    finally in.close()
   }
 
   test("an entry with a supplied CRC round trips, and is really stored") {
@@ -42,14 +48,7 @@ class ZipStoredSuite extends CatsEffectSuite {
         .through(archiver.archive)
         .compile
         .to(Chunk)
-      // Read the archive with a plain ZipInputStream, so that the method is read out of the file itself rather than
-      // through this library's own conversion. Without this the test would still pass if the archiver quietly fell
-      // back to DEFLATED.
-      methods <- IO.blocking {
-        val in = new ZipInputStream(new ByteArrayInputStream(archived.toArray))
-        try Iterator.continually(in.getNextEntry).takeWhile(_ != null).map(_.getMethod).toList
-        finally in.close()
-      }
+      methods <- methodsOf(archived)
       _ = assertEquals(methods, List(ZipOutputStream.STORED))
       obtained <- Stream
         .chunk(archived)
@@ -79,25 +78,140 @@ class ZipStoredSuite extends CatsEffectSuite {
       }
   }
 
-  test("a CRC on a differently named entry is reported rather than quietly dropped") {
+  test("the CRC survives a rename, since renaming does not change the data") {
     val bytes = "hello".getBytes
-    val zipEntry = new ZipEntry("other")
-    zipEntry.setSize(bytes.length.toLong)
-    zipEntry.setCompressedSize(bytes.length.toLong)
-    zipEntry.setCrc(crcOf(bytes))
-    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong)).withUnderlying(zipEntry)
+    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong)).withCrc(crcOf(bytes)).withName("other")
+
+    for {
+      archived <- Stream
+        .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes)))
+        .through(archiver.archive)
+        .compile
+        .to(Chunk)
+      methods <- methodsOf(archived)
+      _ = assertEquals(methods, List(ZipOutputStream.STORED))
+      names <- Stream
+        .chunk(archived)
+        .through(ZipUnarchiver[IO].unarchive)
+        .map { case (entry, _) => entry.name }
+        .compile
+        .toList
+      _ = assertEquals(names, List("other"))
+    } yield ()
+  }
+
+  test("a CRC is dropped when the size no longer agrees with it") {
+    val bytes = "hello".getBytes
+    // The CRC belongs to the original data. Declaring a different size means that data has been replaced, so keeping
+    // the CRC would write an archive that fails to extract.
+    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong))
+      .withCrc(crcOf(bytes))
+      .withUncompressedSize(Some(bytes.length.toLong + 1))
 
     Stream
-      .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes)))
+      .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes ++ Array[Byte]('!'))))
       .through(archiver.archive)
       .compile
       .drain
       .attempt
       .map {
-        case Left(_: IllegalArgumentException) => ()
+        case Left(e: IllegalArgumentException) =>
+          assert(e.getMessage.contains("test"), s"the message should name the entry, got: ${e.getMessage}")
         case Left(other) => fail(s"expected an IllegalArgumentException but got $other")
-        case Right(_) => fail("the mismatched name should have been reported")
+        case Right(_) => fail("a CRC belonging to different data was allowed through")
       }
+  }
+
+  test("an entry carrying another archive's method and compressed size is still written stored") {
+    val bytes = "hello".getBytes
+    // What an entry read out of a deflated archive looks like: it brings that archive's method and compressed size
+    // with it. Taken as they are, the entry would be written deflated, with a compressed size describing data this
+    // archive is not writing.
+    val zipEntry = new ZipEntry("test")
+    zipEntry.setMethod(ZipOutputStream.DEFLATED)
+    zipEntry.setSize(bytes.length.toLong)
+    zipEntry.setCompressedSize(2L)
+    zipEntry.setCrc(crcOf(bytes))
+    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong)).withUnderlying(zipEntry)
+
+    for {
+      archived <- Stream
+        .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes)))
+        .through(archiver.archive)
+        .compile
+        .to(Chunk)
+      methods <- methodsOf(archived)
+      _ = assertEquals(methods, List(ZipOutputStream.STORED))
+      obtained <- Stream
+        .chunk(archived)
+        .through(ZipUnarchiver[IO].unarchive)
+        .flatMap { case (_, data) => data }
+        .chunkAll
+        .compile
+        .lastOrError
+      _ = assert(util.Arrays.equals(obtained.toArray, bytes))
+    } yield ()
+  }
+
+  test("a deflated archiver ignores a compressed size belonging to another archive") {
+    val bytes = ("hello world " * 100).getBytes
+    // Deflating produces a compressed size of its own. Taking the one the entry arrived with, writing rejects the
+    // entry outright: "invalid entry compressed size".
+    val zipEntry = new ZipEntry("test")
+    zipEntry.setMethod(ZipOutputStream.DEFLATED)
+    zipEntry.setSize(bytes.length.toLong)
+    zipEntry.setCompressedSize(2L)
+    zipEntry.setCrc(crcOf(bytes))
+    val entry = ArchiveEntry[Some, Any]("test", Some(bytes.length.toLong)).withUnderlying(zipEntry)
+
+    for {
+      archived <- Stream
+        .emit(entry -> Stream.chunk[IO, Byte](Chunk.array(bytes)))
+        .through(ZipArchiver.makeDeflated[IO]().archive)
+        .compile
+        .to(Chunk)
+      methods <- methodsOf(archived)
+      _ = assertEquals(methods, List(ZipOutputStream.DEFLATED))
+      obtained <- Stream
+        .chunk(archived)
+        .through(ZipUnarchiver[IO].unarchive)
+        .flatMap { case (_, data) => data }
+        .chunkAll
+        .compile
+        .lastOrError
+      _ = assert(util.Arrays.equals(obtained.toArray, bytes))
+    } yield ()
+  }
+
+  test("an entry read back out of an archive brings its CRC with it") {
+    for {
+      random <- Random.scalaUtilRandom[IO]
+      expected <- random.nextBytes(4096)
+      archived <- Stream
+        .emit(storedEntry("test", expected) -> Stream.chunk[IO, Byte](Chunk.array(expected)))
+        .through(archiver.archive)
+        .compile
+        .to(Chunk)
+      // Archive the entries again with no CRC supplied anywhere. The one that comes back out of the unarchiver
+      // already carries it.
+      copied <- Stream
+        .chunk(archived)
+        .through(ZipUnarchiver[IO].unarchive)
+        .map { case (entry, data) => entry.withUncompressedSize(Some(expected.length.toLong)) -> data }
+        .through(archiver.archive)
+        .compile
+        .to(Chunk)
+      methods <- methodsOf(copied)
+      _ = assertEquals(methods, List(ZipOutputStream.STORED))
+      obtained <- Stream
+        .chunk(copied)
+        .through(ZipUnarchiver[IO].unarchive)
+        .flatMap { case (_, data) => data }
+        .chunkAll
+        .compile
+        .lastOrError
+      _ = assert(util.Arrays.equals(obtained.toArray, expected))
+    } yield ()
   }
 
   test("directories and empty entries need no CRC from the caller") {


### PR DESCRIPTION
`ZipArchiver.makeStored` has never worked. It throws on the first entry with data:

```
java.util.zip.ZipException: STORED entry missing size, compressed size, or crc-32
```

Of the three fields that message names, only one is really missing. `size` comes from `uncompressedSize` and the type already guarantees it. `csize` is derived by the STORED branch when it is `-1`. **The CRC is never set anywhere.** It also cannot be derived: a CRC needs all the data, and STORED writes it into the local header ahead of the data. `java.util.zip.ZipOutputStream` reaches the data descriptor only from the DEFLATED branch and resets `flag` to `0` before the method switch, so there is no streaming way around it. For this backend the caller is the only one who can supply it.

## Giving an entry its CRC

The zip module gains `withCrc`:

```scala
ArchiveEntry[Some, Any]("photo.jpg", Some(size)).withCrc(crc) -> data
```

It sets the CRC on the native entry the conversion already knows how to build, so nothing about `java.util.zip` reaches the caller and there is no name to keep in sync. Compute the value with `java.util.zip.CRC32`. Directories and empty entries need nothing, since their CRC is zero, and neither does an entry read out of another zip — it brings its CRC with it.

Keeping `makeStored` an ordinary `Archiver[F, Some]` means a missing CRC is a runtime error rather than a compile error. Making it a compile error is possible, but only by taking `makeStored` out of the `Archiver` interface — `Archiver.archive` is fixed at `ArchiveEntry[Size, Any]`, so the `Underlying` type is erased at that boundary. That would cost `ArchiveSingleFileCompressor` and every generic use for the one archiver that needs extra data. The error names the entry and says what to do instead.

## A CRC belongs to the data, not to the name

`zipArchiveEntryToUnderlying` discards the native entry when the name or directory flag changes, because it may no longer be valid under the new name (ADR 0011). The CRC went with it. But renaming an entry does not change the data the CRC was taken over, so it is now carried across to the rebuilt entry.

Whether the native entry can be reused stays a question about the entry rather than about its data: it is taken as it is when the name and directory flag still match, and rebuilt from the model otherwise. Data that has really changed needs a new CRC, which is the caller's to give.

## Two corrections on the copy path

An entry read out of one archive and written to another brings that archive's method and compressed size with it. Both were taken as they came, so:

- a stored archiver quietly wrote copied entries **deflated**, ignoring the factory that was chosen;
- deflating an entry that declared someone else's compressed size failed outright — verified, `invalid entry compressed size (expected 2 but got 25 bytes)`.

An archiver now writes the method its factory names and sets the compressed size to match what it is about to write. This does mean an entry can no longer carry its own method through: mixed stored-and-deflated archives are not expressible in the model and were not reachable before either, since the stored half never worked.

## Verification

Seven tests in `ZipStoredSuite`, all new or reworked:

- an entry with a supplied CRC round trips, and really is STORED — read back with a plain `ZipInputStream` so the assertion cannot pass on a silent DEFLATED fallback
- an entry without a CRC is reported before anything is written, by name
- the CRC survives a rename
- an entry carrying another archive's method and compressed size is still written stored
- a deflated archiver ignores a compressed size belonging to another archive
- an entry read back out of an archive brings its CRC with it, and re-archives with no CRC supplied anywhere
- directories and empty entries need no CRC

Full matrix green: 150 runs across 2.12, 2.13 and 3, JVM and Scala.js. `ZipRoundTripSuite`, `ZipCancellationSuite`, `ZipUnarchiveEntriesSuite` and `ZipMemorySuite` are untouched.

## Notes

- No ADR here yet. This changes the documented contract of `makeStored` and deserves one, but #346 already claims `0022` and would collide on the number and on `docs/adr/README.md`. The reasoning is recorded above; the ADR follows once the numbering settles.
- zip4j needs none of this: its `ZipOutputStream` computes the CRC itself and back-patches it, so STORE there would need only the size. But `Zip4JArchiver` never sets a method at all, so STORE is unreachable in that module today.

