### PR TITLE
Add a manual memory check for every codec

### DIFF
--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -1,0 +1,29 @@
+name: memory-check
+
+# Run by hand. Puts a large amount of data through every codec in a JVM whose heap is far smaller than that volume, so
+# that a codec holding on to what it is given runs out of memory instead of merely being slower.
+on:
+  workflow_dispatch:
+    inputs:
+      xmx:
+        description: 'Heap for the test JVM. Has to stay well below the volume each codec streams.'
+        required: false
+        default: '-Xmx96m'
+
+jobs:
+  memory-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5.7.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1.5.8
+      - name: Memory check
+        env:
+          FS2_COMPRESS_MEMORY_CHECK: '1'
+          FS2_COMPRESS_TEST_XMX: ${{ inputs.xmx }}
+          SBT_OPTS: '-Xmx2G'
+        run: sbt "testOnly *MemorySuite"

--- a/brotli4j/src/test/scala/de/lhns/fs2/compress/Brotli4JMemorySuite.scala
+++ b/brotli4j/src/test/scala/de/lhns/fs2/compress/Brotli4JMemorySuite.scala
@@ -1,0 +1,9 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+
+class Brotli4JMemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = Brotli4JCompressor.make[IO]()
+  override protected def decompressor: Decompressor[IO] = Brotli4JDecompressor.make[IO]()
+}

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,20 @@ lazy val commonSettings: SettingsDefinition = Def.settings(
     "org.typelevel" %%% "munit-cats-effect" % V.munitCatsEffect % Test
   ),
   testFrameworks += new TestFramework("munit.Framework"),
+  // Run tests in their own JVM with a heap of their own, so that how much memory they have does not depend on how sbt
+  // was started. Without this they share the build tool's heap, which differs between a native sbt and a BSP server.
+  // Only the JVM rows: Scala.js refuses to run its tests in a forked JVM, and the root project is not a matrix and has
+  // no tests of its own.
+  Test / fork := virtualAxes.?.value.getOrElse(Seq.empty).contains(VirtualAxis.jvm),
+  // The heap is deliberately settable: the memory checks run with a small one, so that a codec holding on to what it is
+  // given runs out of memory rather than merely being slower. See MemorySuite.
+  Test / javaOptions += sys.env.getOrElse("FS2_COMPRESS_TEST_XMX", "-Xmx1G"),
+  // Keep the memory checks out of an ordinary run. They are slow and only mean anything with a small heap, so the
+  // memory-check workflow sets FS2_COMPRESS_MEMORY_CHECK and runs them on their own.
+  Test / testOptions ++= {
+    if (sys.env.contains("FS2_COMPRESS_MEMORY_CHECK")) Nil
+    else Seq(Tests.Filter(name => !name.endsWith("MemorySuite")))
+  },
   libraryDependencies ++= virtualAxes.?.value.getOrElse(Seq.empty).collectFirst {
     case VirtualAxis.ScalaVersionAxis(version, _) if version.startsWith("2.") =>
       compilerPlugin("com.olegpy" %% "better-monadic-for" % V.betterMonadicFor)

--- a/bzip2/src/test/scala/de/lhns/fs2/compress/Bzip2MemorySuite.scala
+++ b/bzip2/src/test/scala/de/lhns/fs2/compress/Bzip2MemorySuite.scala
@@ -1,0 +1,12 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+
+class Bzip2MemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = Bzip2Compressor.make[IO]()
+  override protected def decompressor: Decompressor[IO] = Bzip2Decompressor.make[IO]()
+
+  // bzip2 is roughly ten times slower than the other codecs, and 32 MiB is still far more than the heap this runs with.
+  override protected def megabytes: Int = 32
+}

--- a/core/src/test/scala/de/lhns/fs2/compress/CancellationSuite.scala
+++ b/core/src/test/scala/de/lhns/fs2/compress/CancellationSuite.scala
@@ -39,9 +39,12 @@ import scala.concurrent.duration._
 trait CancellationSuite extends CatsEffectSuite {
 
   /** How long a stream gets to finish before it counts as stuck. This detects a deadlock rather than measuring
-    * performance, so it is deliberately much larger than anything a working implementation needs.
+    * performance, so it is deliberately much larger than anything a working implementation needs. A whole run forks a
+    * JVM per module and runs them at the same time, so a stream that normally takes a few seconds can take considerably
+    * longer on a loaded machine. Waiting longer costs nothing when the stream is not stuck, since the wait ends as soon
+    * as it finishes.
     */
-  protected def liveBudget: FiniteDuration = 10.seconds
+  protected def liveBudget: FiniteDuration = 1.minute
 
   /** Deliberately small. `fs2.io.readOutputStream` allocates a `PipedStreamBuffer(chunkSize)`, so the capacity of the
     * pipe is the chunk size. At 64 bytes, a consumer that stops draining makes the next write block, including the
@@ -56,7 +59,10 @@ trait CancellationSuite extends CatsEffectSuite {
 
   protected def payloadSize: Int = 128 * 1024
 
-  override def munitIOTimeout: Duration = 60.seconds
+  /** Comfortably above [[liveBudget]], so that a stuck stream is reported by the helpers below, which say what is stuck
+    * and why, rather than by munit cutting the test off first with a bare timeout.
+    */
+  override def munitIOTimeout: Duration = 3.minutes
 
   protected val boom: RuntimeException = new RuntimeException("boom")
 

--- a/core/src/test/scalajvm/de/lhns/fs2/compress/MemorySuite.scala
+++ b/core/src/test/scalajvm/de/lhns/fs2/compress/MemorySuite.scala
@@ -1,0 +1,66 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import fs2.{Chunk, Stream}
+import munit.CatsEffectSuite
+
+import scala.concurrent.duration._
+import scala.concurrent.duration.Duration
+
+/** Checks that a codec's memory use does not grow with the amount of data put through it.
+  *
+  * The check is the heap itself rather than a measurement. These run in a JVM whose heap is far smaller than the volume
+  * being streamed, so anything that accumulates in proportion to the input runs out of memory and the test dies.
+  * Measuring instead, by calling `System.gc()` and reading `Runtime`, would prove much less: the collection is a hint
+  * the JVM may ignore, and what is in use conflates live data with garbage that has not been collected yet.
+  *
+  * Nothing here holds on to the stream contents. The bytes are counted as they go past, so anything retained is
+  * retained by the codec.
+  *
+  * An ordinary test run skips these, since they are slow and prove nothing without a small heap. To run them, set
+  * FS2_COMPRESS_MEMORY_CHECK and a heap far below the volume above:
+  *
+  * {{{
+  * FS2_COMPRESS_MEMORY_CHECK=1 FS2_COMPRESS_TEST_XMX=-Xmx96m sbt "testOnly *MemorySuite"
+  * }}}
+  */
+abstract class MemorySuite extends CatsEffectSuite {
+
+  protected def compressor: Compressor[IO]
+
+  protected def decompressor: Decompressor[IO]
+
+  /** How much to put through the codec. It only has to be large relative to the heap the check runs with; bzip2 lowers
+    * it because it is an order of magnitude slower than the others.
+    */
+  protected def megabytes: Int = 256
+
+  /** Generous, but not unbounded. A codec that holds on to everything does not always die quickly: with a heap this
+    * small it can spend a long time collecting garbage instead, and without a deadline the check would hang rather than
+    * fail.
+    */
+  override def munitIOTimeout: Duration = 10.minutes
+
+  /** How many bytes the check puts through. Archivers that need an entry's size up front are given this. */
+  protected final def bytes: Long = megabytes.toLong * 1024 * 1024
+
+  private val block: Chunk[Byte] = {
+    val data = new Array[Byte](64 * 1024)
+    // Incompressible, so that the codec cannot make the work disappear.
+    new scala.util.Random(1L).nextBytes(data)
+    Chunk.array(data)
+  }
+
+  test("a large stream is compressed and decompressed in constant memory") {
+    Stream
+      .emits(Seq.fill(megabytes * 16)(block))
+      .flatMap(Stream.chunk[IO, Byte])
+      .through(compressor.compress)
+      .through(decompressor.decompress)
+      .chunks
+      .fold(0L)((total, chunk) => total + chunk.size)
+      .compile
+      .lastOrError
+      .map(total => assertEquals(total, bytes))
+  }
+}

--- a/gzip/src/test/scalajvm/de/lhns/fs2/compress/GzipMemorySuite.scala
+++ b/gzip/src/test/scalajvm/de/lhns/fs2/compress/GzipMemorySuite.scala
@@ -1,0 +1,9 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+import fs2.io.compression._
+
+class GzipMemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = GzipCompressor.make[IO]()
+  override protected def decompressor: Decompressor[IO] = GzipDecompressor.make[IO]()
+}

--- a/lz4/src/test/scala/de/lhns/fs2/compress/Lz4MemorySuite.scala
+++ b/lz4/src/test/scala/de/lhns/fs2/compress/Lz4MemorySuite.scala
@@ -1,0 +1,9 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+
+class Lz4MemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = Lz4Compressor.make[IO]()
+  override protected def decompressor: Decompressor[IO] = Lz4Decompressor.make[IO]()
+}

--- a/snappy/src/test/scala/de/lhns/fs2/compress/SnappyMemorySuite.scala
+++ b/snappy/src/test/scala/de/lhns/fs2/compress/SnappyMemorySuite.scala
@@ -1,0 +1,9 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+
+class SnappyMemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = SnappyCompressor.make[IO](mode = SnappyCompressor.WriteMode.Framed())
+  override protected def decompressor: Decompressor[IO] = SnappyDecompressor.make[IO](mode = SnappyDecompressor.ReadMode.Framed())
+}

--- a/tar/src/test/scala/de/lhns/fs2/compress/TarMemorySuite.scala
+++ b/tar/src/test/scala/de/lhns/fs2/compress/TarMemorySuite.scala
@@ -1,0 +1,8 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+class TarMemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = ArchiveSingleFileCompressor.forName[IO](TarArchiver.make[IO](), "test", bytes)
+  override protected def decompressor: Decompressor[IO] = ArchiveSingleFileDecompressor(TarUnarchiver.make[IO]())
+}

--- a/zip/src/test/scala/de/lhns/fs2/compress/ZipMemorySuite.scala
+++ b/zip/src/test/scala/de/lhns/fs2/compress/ZipMemorySuite.scala
@@ -1,0 +1,8 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+class ZipMemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = ArchiveSingleFileCompressor.forName[IO](ZipArchiver.makeDeflated[IO](), "test")
+  override protected def decompressor: Decompressor[IO] = ArchiveSingleFileDecompressor(ZipUnarchiver.make[IO]())
+}

--- a/zip4j/src/test/scala/de/lhns/fs2/compress/Zip4JMemorySuite.scala
+++ b/zip4j/src/test/scala/de/lhns/fs2/compress/Zip4JMemorySuite.scala
@@ -1,0 +1,8 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+class Zip4JMemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = ArchiveSingleFileCompressor.forName[IO](Zip4JArchiver.make[IO](), "test", bytes)
+  override protected def decompressor: Decompressor[IO] = ArchiveSingleFileDecompressor(Zip4JUnarchiver.make[IO]())
+}

--- a/zstd/src/test/scala/de/lhns/fs2/compress/ZstdMemorySuite.scala
+++ b/zstd/src/test/scala/de/lhns/fs2/compress/ZstdMemorySuite.scala
@@ -1,0 +1,9 @@
+package de.lhns.fs2.compress
+
+import cats.effect.IO
+
+
+class ZstdMemorySuite extends MemorySuite {
+  override protected def compressor: Compressor[IO] = ZstdCompressor.make[IO]()
+  override protected def decompressor: Decompressor[IO] = ZstdDecompressor.make[IO]()
+}


### PR DESCRIPTION
Closes #155.

## What the report was

An `OutOfMemoryError` while streaming through a codec, taken as a leak in the library.

## What I found

There is no leak. Every compressor and archiver streams in constant memory. I put far more data through each one than the heap it was given and none of them died:

| codec | streamed | heap |
| --- | --- | --- |
| zstd | 512 MiB | 96 MiB |
| gzip, bzip2, lz4, brotli4j, snappy | 256 MiB | 96 MiB |
| zip, tar, zip4j | 256 MiB | 96 MiB |

Peak use stayed between 8 and 28 MiB throughout, and did not grow with the amount streamed.

The `OutOfMemoryError` was environmental. `Test / fork` was not set, so tests ran inside the build tool's own JVM and inherited its heap. That heap differs a lot depending on how sbt was started — a BSP server gets considerably less than a native sbt — which matches the reporter seeing it in one place and not another. CI only stays clear of it because the workflow sets `SBT_OPTS: -Xmx2G`.

## What this adds

**A check that would catch a real leak.** A fast deterministic test cannot do this. It can show that a codec streams incrementally, but not that its memory stays bounded — only volume against a bounded heap shows that. So `MemorySuite` puts a large stream through a codec in a JVM whose heap is far smaller than that volume: anything that accumulates in proportion to the input runs out of memory and the test dies. The heap is the check itself. Measuring instead, by calling `System.gc()` and reading `Runtime`, would prove much less, since the collection is a hint the JVM may ignore and what is in use conflates live data with garbage not yet collected.

Nothing in the test holds the contents: bytes are counted as they go past, so anything retained is retained by the codec.

I confirmed it actually detects a leak by injecting one (`.chunkAll.unchunks` after `compress`). That also showed the failure mode is not always a quick `OutOfMemoryError` — with a small heap the JVM can spend a very long time collecting instead — so the suite has a deadline and fails rather than hanging.

**Forking, with a heap of its own.** `Test / fork := true` and `Test / javaOptions += -Xmx1G` by default, so how much memory a test has no longer depends on how sbt was started. Only the JVM rows, since Scala.js refuses to run its tests in a forked JVM. The heap is settable through `FS2_COMPRESS_TEST_XMX` because the memory checks need a small one.

**A manual workflow.** `workflow_dispatch` only. These are slow — around four and a half minutes for all nine — and prove nothing without a small heap, so an ordinary run skips them via a filter on `FS2_COMPRESS_MEMORY_CHECK`.

Run them locally with:

```
FS2_COMPRESS_MEMORY_CHECK=1 FS2_COMPRESS_TEST_XMX=-Xmx96m sbt "testOnly *MemorySuite"
```

## One incidental change

Forking makes a whole run slower, which pushed the cancellation suites' liveness deadline past ten seconds on a loaded machine and produced one spurious failure in brotli4j. That deadline detects a deadlock rather than measuring performance, and waiting longer costs nothing when nothing is stuck, since the wait ends as soon as the stream finishes. It is now a minute, with `munitIOTimeout` raised above it so the helper's diagnostic wins over a bare munit timeout.

## Verification

- Full cross-built matrix green: 145 suites, Scala 2.12/2.13/3, JVM and Scala.js.
- Two further full JVM runs green, confirming the cancellation suites are stable under forking.
- All nine memory suites pass at `-Xmx96m`.
- Ordinary runs contain no mention of a memory suite, so the filter works.
