### PR TITLE
Say what is missing when there is no instance in scope

### DIFF
--- a/core/src/main/scala/de/lhns/fs2/compress/Archiver.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Archiver.scala
@@ -4,6 +4,12 @@ import cats.effect.{Async, Ref}
 import cats.syntax.all._
 import fs2.{Pipe, Stream}
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Archiver[${F}, ${Size}] in scope. Build one with a codec's make, for example `ZipArchiver.makeDeflated()`, and " +
+    "make it implicit."
+)
 trait Archiver[F[_], Size[A] <: Option[A]] {
   def archive: Pipe[F, (ArchiveEntry[Size, Any], Stream[F, Byte]), Byte]
 }

--- a/core/src/main/scala/de/lhns/fs2/compress/Compressor.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Compressor.scala
@@ -2,6 +2,12 @@ package de.lhns.fs2.compress
 
 import fs2.Pipe
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Compressor[${F}] in scope. Build one with a codec's make, for example `GzipCompressor.make()`, and make it " +
+    "implicit."
+)
 trait Compressor[F[_]] {
   def compress: Pipe[F, Byte, Byte]
 }

--- a/core/src/main/scala/de/lhns/fs2/compress/Decompressor.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Decompressor.scala
@@ -2,6 +2,12 @@ package de.lhns.fs2.compress
 
 import fs2.Pipe
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Decompressor[${F}] in scope. Build one with a codec's make, for example `GzipDecompressor.make()`, and make it " +
+    "implicit."
+)
 trait Decompressor[F[_]] {
   def decompress: Pipe[F, Byte, Byte]
 }

--- a/core/src/main/scala/de/lhns/fs2/compress/Unarchiver.scala
+++ b/core/src/main/scala/de/lhns/fs2/compress/Unarchiver.scala
@@ -4,6 +4,12 @@ import cats.effect.{Async, Ref}
 import cats.syntax.all._
 import fs2.{Pipe, Stream}
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "No Unarchiver[${F}, ${Size}, ${Underlying}] in scope. Build one with a codec's make, for example " +
+    "`ZipUnarchiver.make()`, and make it implicit."
+)
 trait Unarchiver[F[_], Size[A] <: Option[A], Underlying] {
   def unarchive: Pipe[F, Byte, (ArchiveEntry[Size, Underlying], Stream[F, Byte])]
 }


### PR DESCRIPTION
Split out of #346, which is otherwise not going ahead.

Summoning a missing instance gives you the trait's name and nothing else, which is no help if you do not already know that instances come from a codec's `make`. All four core traits now say so:

```
No Compressor[cats.effect.IO] in scope. Build one with a codec's make, for example
`GzipCompressor.make()`, and make it implicit.

No Unarchiver[cats.effect.IO, Option, String] in scope. Build one with a codec's make,
for example `ZipUnarchiver.make()`, and make it implicit.
```

`Archiver` points at `ZipArchiver.makeDeflated()` rather than the deprecated `make`.

The messages in #346 pointed at `import GzipCompressor.default._`, which does not exist without that PR, so they name `make` instead.

## Checks

Both messages verified to render with their type parameters substituted, on Scala 3 and on 2.12 — the two that format implicit errors differently. Full matrix green: 90 runs, `scalafmtCheckAll` clean.
