### PR TITLE
Fix the README examples, and record the open question about default instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ Compression can be abstracted over using the `Compressor` typeclass. Adapt the f
 ```scala
 import cats.effect.Async
 import de.lhns.fs2.compress._
+import fs2.compression.Compression // gzip needs a Compression[F]; the other codecs do not
 import fs2.io.file.{Files, Path}
 
 // implicit def bzip2[F[_]: Async]: Compressor[F] = Bzip2Compressor.make()
 // implicit def lz4[F[_]: Async]: Compressor[F] = Lz4Compressor.make()
 // implicit def zstd[F[_]: Async]: Compressor[F] = ZstdCompressor.make()
-implicit def gzip[F[_]: Async]: Compressor[F] = GzipCompressor.make()
+implicit def gzip[F[_]: Async: Compression]: Compressor[F] = GzipCompressor.make()
 
 def compressFile[F[_]: Async](toCompress: Path, writeTo: Path)(implicit compressor: Compressor[F]): F[Unit] =
   Files[F]
@@ -117,17 +118,18 @@ Similarly, decompression can be abstracted over using the `Decompressor` typecla
 ```scala
 import cats.effect.Async
 import de.lhns.fs2.compress._
+import fs2.compression.Compression // gzip needs a Compression[F]; the other codecs do not
 import fs2.io.file.{Files, Path}
 
 // implicit def brotli[F[_]: Async]: Decompressor[F] = BrotliDecompressor.make()
 // implicit def bzip2[F[_]: Async]: Decompressor[F] = Bzip2Decompressor.make()
 // implicit def lz4[F[_]: Async]: Decompressor[F] = Lz4Decompressor.make()
 // implicit def zstd[F[_]: Async]: Decompressor[F] = ZstdDecompressor.make()
-implicit def gzip[F[_]: Async]: Decompressor[F] = GzipDecompressor.make()
+implicit def gzip[F[_]: Async: Compression]: Decompressor[F] = GzipDecompressor.make()
 
 def decompressFile[F[_]: Async](toDecompress: Path, writeTo: Path)(implicit decompressor: Decompressor[F]): F[Unit] =
   Files[F]
-    .readAll(toCompress)
+    .readAll(toDecompress)
     .through(decompressor.decompress)
     .through(Files[F].writeAll(writeTo))
     .compile
@@ -140,6 +142,7 @@ The library supports both `.zip` and `.tar` archives, with support for `.zip` th
 
 ```scala
 import cats.effect.Async
+import cats.syntax.functor._
 import de.lhns.fs2.compress._
 import fs2.io.file.{Files, Path}
 
@@ -147,7 +150,7 @@ import fs2.io.file.{Files, Path}
 // implicit def zip4j[F[_]: Async]: Archiver[F, Some] = Zip4JArchiver.make()
 implicit def zip[F[_]: Async]: Archiver[F, Option] = ZipArchiver.makeDeflated()
 
-def archiveDirectory[F[_]](directory: Path, writeTo: Path)(implicit archiver: Archiver[F, Option]): F[Unit] =
+def archiveDirectory[F[_]: Async](directory: Path, writeTo: Path)(implicit archiver: Archiver[F, Option]): F[Unit] =
   Files[F]
     .list(directory)
     .evalMap { path =>
@@ -169,10 +172,12 @@ the `GzipCompressor`
 
 ```scala
 import cats.effect.Async
+import cats.syntax.functor._
 import de.lhns.fs2.compress._
+import fs2.compression.Compression
 import fs2.io.file.{Files, Path}
 
-implicit def gzip[F[_]: Async]: Compressor[F] = GzipCompressor.make()
+implicit def gzip[F[_]: Async: Compression]: Compressor[F] = GzipCompressor.make()
 implicit def tar[F[_]: Async]: Archiver[F, Some] = TarArchiver.make()
 
 def tarAndGzip[F[_]: Async](directory: Path, writeTo: Path)(implicit archiver: Archiver[F, Some], compressor: Compressor[F]): F[Unit] =
@@ -203,11 +208,14 @@ import cats.effect.Async
 import de.lhns.fs2.compress._
 import fs2.io.file.{Files, Path}
 
-// implicit def tar[F[_]: Async]: Unarchiver[F, Option] = TarUnarchiver.make()
-// implicit def zip4j[F[_]: Async]: Unarchiver[F, Option] = Zip4JUnarchiver.make()
-implicit def zip[F[_]: Async]: Unarchiver[F, Option] = ZipUnarchiver.make()
+// implicit def tar[F[_]: Async]: TarUnarchiver[F] = TarUnarchiver.make()
+// implicit def zip4j[F[_]: Async]: Zip4JUnarchiver[F] = Zip4JUnarchiver.make()
+implicit def zip[F[_]: Async]: ZipUnarchiver[F] = ZipUnarchiver.make()
 
-def unArchive[F[_]](archive: Path, writeTo: Path)(implicit archiver: Unarchiver[F, Option]): F[Unit] =
+// Underlying is the archive format's own entry type, which the unarchiver hands back with each entry
+def unArchive[F[_]: Async, Underlying](archive: Path, writeTo: Path)(implicit
+    archiver: Unarchiver[F, Option, Underlying]
+): F[Unit] =
   Files[F]
     .readAll(archive)
     .through(archiver.unarchive)
@@ -222,12 +230,16 @@ Once again if you have a `.tar.gz` file you will have to combine the `Unarchiver
 ```scala
 import cats.effect.Async
 import de.lhns.fs2.compress._
+import fs2.compression.Compression
 import fs2.io.file.{Files, Path}
 
-implicit def gzip[F[_]: Async]: Decompressor[F] = GzipDecompressor.make()
-implicit def tar[F[_]: Async]: Unarchiver[F, Option] = TarUnarchiver.make()
+implicit def gzip[F[_]: Async: Compression]: Decompressor[F] = GzipDecompressor.make()
+implicit def tar[F[_]: Async]: TarUnarchiver[F] = TarUnarchiver.make()
 
-def unArchive[F[_]](archive: Path, writeTo: Path)(implicit archiver: Unarchiver[F, Option], decompressor: Decompress[F]): F[Unit] =
+def unArchive[F[_]: Async, Underlying](archive: Path, writeTo: Path)(implicit
+    archiver: Unarchiver[F, Option, Underlying],
+    decompressor: Decompressor[F]
+): F[Unit] =
   Files[F]
     .readAll(archive)
     .through(decompressor.decompress)

--- a/docs/adr/0022-leave-default-instances-undecided.md
+++ b/docs/adr/0022-leave-default-instances-undecided.md
@@ -1,0 +1,97 @@
+# 22. Leave default instances undecided for now
+
+Date: 2026-08-26
+
+## Status
+
+Proposed.
+
+## Context
+
+Issue #154 asked for convenience on the companions, so that using a codec with no
+configuration would not mean writing `make()` and binding the result. A follow-up question in
+that issue suggested something better than the original proposal: put the convenience in an
+object to import rather than in a method.
+
+That was built and spiked. Every companion gained a nested `default` object holding an
+implicit instance from `make()`:
+
+```scala
+import GzipCompressor.default._
+
+GzipCompressor[IO].compress
+```
+
+The request is reasonable and the result is convenient. The question is not whether the idea
+is any good; it is whether this library knows enough yet to commit to a shape.
+
+## Decision
+
+Do not add them yet. `make()` stays the only way to obtain an instance for now, and this is
+recorded so the question can be picked up again rather than rediscovered.
+
+**It is a one-way door.** Under early-semver (ADR 0017) a `default` object on each of about
+twenty-two companions is public API for the whole 2.x line. `ZipArchiver.make` is the standing
+example of how that goes: deprecated in ADR 0012 and still present, several minor releases
+later, because removing it would be breaking. An implicit instance is harder to withdraw than
+a method, because taking it out of scope does not fail a caller's build — it changes which
+instance their code resolves to, quietly. Adding it later costs nothing; adding it now and
+finding the shape wrong costs the rest of the major version.
+
+**The shape is not settled.** Open questions, none of which have an obvious answer today:
+
+- Implicit, or a plain value written out at the use site? A plain `GzipCompressor.default[IO]`
+  has no resolution behaviour to reason about, but differs from `GzipCompressor.make()` by a
+  few characters, which makes it hard to justify as a second name for one thing.
+- What should happen where a caller has their own instance? Measured on this build, with
+  `import GzipCompressor.default._` in scope alongside an instance configured with
+  `deflateLevel = Some(9)`:
+
+  | the instance you wrote | what is summoned | result |
+  |---|---|---|
+  | `implicit val c: Compressor[IO]` | `Compressor[IO]` | yours |
+  | `implicit val c: Compressor[IO]` | `GzipCompressor[IO]` | the default |
+  | `implicit val c: GzipCompressor[IO]` | `GzipCompressor[IO]` | yours, on 2.13 and 3 |
+  | `implicit val c: GzipCompressor[IO]` | `GzipCompressor[IO]` | ambiguity error on 2.12 |
+
+  The second row is the one to have an answer for. An instance annotated with the abstract
+  trait is not a candidate for a summon of the concrete type at all, so the default is the only
+  candidate. Without the import that line does not compile, so the effect of adding a default
+  is to turn a compile error into a codec configured differently from how the caller wrote it.
+  Whether that is acceptable, and whether a library should have to teach "annotate with the
+  concrete type" to avoid it, is exactly what is undecided.
+- The bottom two rows also mean an import and a caller's own instance cannot coexist on 2.12,
+  which the build still cross-builds. That constraint may lift on its own.
+
+These traits are also not type classes in the sense that makes implicit resolution
+uncontroversial. There is no canonical gzip compressor for an `F` — deflate level, strategy
+and chunk size are all legitimate variations, and zip carries a compression method as well
+(ADR 0009). An instance is a bundle of configuration. That does not settle the question either
+way, but it is why the rows above are not a detail.
+
+## Considered options
+
+- **Convenience methods on the companion**, as #154 originally proposed:
+  `GzipCompressor.compress[IO]()`. Set aside: it saves a few characters, still needs the
+  explicit `[IO]`, does not help where an instance is passed into a polymorphic function, and
+  multiplies where a companion has more than one factory — `ZipArchiver` would need one per
+  compression method.
+- **Ship the `default` objects now.** Deferred rather than rejected, for the reasons above.
+- **A non-implicit `default` value.** Still open; see the first question.
+
+## Consequences
+
+- Obtaining an instance is `make()`, and there is one way to do it (ADR 0005). A caller who
+  wants no configuration writes one binding, which is the cost of waiting.
+- The spike is not thrown away: it is on the `default-instances` branch, with a suite per
+  module, so revisiting this does not start from nothing.
+- Because the error a caller meets today is "no instance in scope", the four core traits carry
+  an `@implicitNotFound` naming `make`.
+- If this is revisited, the questions above are the ones to answer first, and the answer should
+  arrive before the next major version rather than during one.
+
+## References
+
+- Issue #154 "Add convenience functions to companion objects"
+- `default-instances` branch — the spike
+- `core/src/main/scala/de/lhns/fs2/compress/{Compressor,Decompressor,Archiver,Unarchiver}.scala`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ supersedes it.
 | [0019](0019-share-the-output-stream-plumbing.md) | Share the `readOutputStream` plumbing in `OutputStreams` | Accepted |
 | [0020](0020-assert-cancellation-by-counting-not-timing.md) | Assert cancellation by counting bytes, not by elapsed time | Accepted |
 | [0021](0021-skipping-entries-and-stale-reads.md) | Let entries be skipped, and fail when reading data the archive has passed | Proposed |
+| [0022](0022-leave-default-instances-undecided.md) | Leave default instances undecided for now | Proposed |
 
 ## Threads worth following
 
@@ -56,3 +57,7 @@ when a consumer skips an entry.
 **When to add a module rather than change one.** 0002 established one artifact per codec,
 0007 and 0015 both applied it by adding a second implementation of a format rather than
 replacing the first, and 0014 wrote down the shape a new module follows.
+
+**How a caller gets an instance.** 0005 settled that `apply` summons and `make` constructs,
+0006 explains why gzip's `make` asks for more than the others, and 0022 is the open question
+of whether there should be a third way that skips `make` altogether.


### PR DESCRIPTION
The rest of what is worth keeping from #346. The `@implicitNotFound` half is #351.

## The README examples did not compile

Nothing compiles them — there is no mdoc — so they had drifted. I copied each one into a scratch source file in the module that has its dependencies and compiled it. That found **six** errors, rather than the four #346 listed:

1. `decompressFile` reads `toCompress`, the path from the *compression* example above it.
2. `Decompress[F]` — no such type. It is `Decompressor[F]`.
3. `Unarchiver[F, Option]` is missing the third parameter, the archive format's own entry type. Two places.
4. `archiveDirectory` and `unArchive` are declared `[F[_]]` but use `Files[F]`, which needs `Async`.
5. `.map` on the `F[Long]` from `Files[F].size` with no `cats.syntax.functor._` imported. Two places.
6. `GzipCompressor.make()` / `GzipDecompressor.make()` called with only an `Async` bound. The JVM finds a `Compression[F]` on its own, so this one compiles there and **fails on Scala.js**, where fs2 offers nothing for a bare `Async[F]` (ADR 0006).

The last two are not in #346's list, and 6 is the one worth having: `gzip` is one of only two modules cross-built to JS, so the example was broken for exactly the platform where the requirement is real.

For the `Unarchiver` fix I made the examples generic in `Underlying` rather than naming `java.util.zip.ZipEntry` and `TarArchiveEntry`, so a reader is not led to import a JDK or commons-compress type to write a function signature.

Every example now compiles, on the JVM and on Scala.js for the gzip ones.

## ADR 0022

Records that default instances are **not decided yet**, rather than rejected.

The reason to wait is that it is a one-way door. Under early-semver (ADR 0017) a `default` object on each of about twenty-two companions is public API for the whole 2.x line, and an implicit is harder to withdraw than a method: taking it out of scope does not fail a caller's build, it changes what their code resolves to. `ZipArchiver.make` is the standing example — deprecated in ADR 0012, still present. Adding this later costs nothing; adding it now and finding the shape wrong costs the rest of the major version.

The shape genuinely is not settled. Implicit or a plain value? And what should happen where a caller has their own instance — measured here, with `import GzipCompressor.default._` alongside an instance configured with `deflateLevel = Some(9)`:

| the instance you wrote | what is summoned | result |
|---|---|---|
| `implicit val c: Compressor[IO]` | `Compressor[IO]` | yours |
| `implicit val c: Compressor[IO]` | `GzipCompressor[IO]` | the default |
| `implicit val c: GzipCompressor[IO]` | `GzipCompressor[IO]` | yours, on 2.13 and 3 |
| `implicit val c: GzipCompressor[IO]` | `GzipCompressor[IO]` | ambiguity error on 2.12 |

Row two is the one to have an answer for: an instance annotated with the abstract trait is not a candidate for a summon of the concrete type at all, so the default is the only candidate, and without the import that line would not compile at all. Whether that is acceptable, and whether a library should have to teach "annotate with the concrete type" to avoid it, is the open question — not a verdict.

(This is also not the mechanism #346 gave for that row, "the import is more specific". I checked each case rather than restating it.)

The spike is not thrown away — the ADR points at the `default-instances` branch, so picking this up again does not start from nothing.

## Follow-ups, not in here

- **The examples will rot again.** mdoc is the actual fix; worth its own issue and PR.
- #154 can be closed pointing at ADR 0022, which answers both the original request and the follow-up question in the last comment — as "not yet, and here is what would have to be settled first".

## Checks

Full matrix green: 90 runs, `scalafmtCheckAll` clean. The scratch files used to compile the examples were deleted; only the README and the ADRs change here.
