### PR TITLE
Do not update the dependency graph on Dependabot's runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,12 @@ jobs:
   dependency-graph:
     name: Update Dependency Graph
     runs-on: ubuntu-latest
+    # Submitting a snapshot needs a token that may write to the repository. Runs that Dependabot
+    # triggers are given a read-only one whatever the event, so there this job can only fail.
+    if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v7
       - uses: sbt/setup-sbt@v1.5.8
       - uses: scalacenter/sbt-dependency-submission@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.GITHUB_TOKEN && github.event_name != 'pull_request'


### PR DESCRIPTION
The push build for Dependabot's `actions/setup-java` branch failed. Its pull request build passed, so only the push run shows it:

```
[error] Unexpected status 403 Forbidden with body:
[error] {"message":"Resource not accessible by integration",
         "documentation_url":".../dependency-submission#create-a-snapshot-of-dependencies-for-a-repository",
         "status":"403"}
```

Submitting a snapshot needs a token that may write to the repository, and **every run Dependabot triggers gets a read-only `GITHUB_TOKEN`** — on a push to one of its branches as much as on the pull request. There the job can only fail.

Note this is specific to Dependabot. Scala Steward runs under its own app and its branch pushes get an ordinary token, which is why those have always submitted fine.

## Why the existing guard missed it

```yaml
if: env.GITHUB_TOKEN && github.event_name != 'pull_request'
```

`env.GITHUB_TOKEN` tests whether a token exists, and one always does, including on forks. What varies is what the token may *do*, which no expression can see. And the event here was `push`, so the second half did not apply either.

## The change

```yaml
if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
```

Naming the actor is what GitHub's own documentation recommends for this, and it leaves everything else exactly as it was: the graph is still submitted from every branch and on releases, as before.

The condition sits on the job rather than on its last step, so a run that has nothing to do is skipped outright instead of starting a runner, checking out the repository and installing sbt before deciding. `env.GITHUB_TOKEN` is gone because the `env` context is not available in a job-level `if`, and as above it was not doing any work.

## Checks

- The push run for this branch **runs** the job and submits, since I am the actor — that is the positive case.
- The pull request run **skips** it, as it always did.
- A Dependabot branch will skip it once this is on `main`; the currently open one carries the old workflow until it is rebased or merged.

## Separate observation, not addressed here

Every pull request branch is built twice — once for the `push` event and once for `pull_request` — because the workflow triggers on `push: branches: ['**']` alongside `pull_request`. Restricting the push trigger to `main` would halve the CI for branches, at the cost of no build for a branch that has no pull request open yet. Worth a look, but it is a change to how you work rather than a fix, so I have left it alone.
