### PR TITLE
Point publishTo at the staging directory a release is uploaded from

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,14 @@ jobs:
         env:
           CI_VERSION: ${{ github.ref }}
         run: sbt "; testFull"
+      # Everything a release does apart from the upload, so that a broken publishing setup is
+      # found on the branch that breaks it rather than at the next release. publishTo is forced
+      # here rather than left to the version: a build with no tag is a snapshot, and a snapshot
+      # publishes straight to Sonatype rather than to the staging directory. Nothing may leave
+      # the runner, so the resolver is pinned instead of being derived.
+      - name: Check the release path
+        if: github.event_name == 'push'
+        run: sbt "; set every publishTo := localStaging.value ; publishSigned; sonaBundle"
       - name: Publish
         env:
           CI_VERSION: ${{ github.ref }}

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,14 @@ lazy val commonSettings: SettingsDefinition = Def.settings(
   },
   Compile / doc / sources := Seq.empty,
   publishMavenStyle := true,
+  // sbt knows how to publish to the Central Portal but does not point publishTo anywhere by
+  // itself. A release is staged on disk and uploaded from there by sonaRelease, which refuses a
+  // snapshot, so a build without a tag goes to the snapshot repository instead.
+  publishTo := {
+    val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+    if (version.value.endsWith("-SNAPSHOT")) Some("central-snapshots" at centralSnapshots)
+    else localStaging.value
+  },
   // Publishing to the Central Portal looks credentials up by host.
   credentials ++= (for {
     username <- sys.env.get("SONATYPE_USERNAME")


### PR DESCRIPTION
The 3.0.0 release failed. Tests passed, then Publish died immediately — 78 times, once per publishable row:

```
java.lang.RuntimeException: Repository for publishing is not specified.
  at sbt.Classpaths$.getPublishTo(Defaults.scala:4279)
```

**This came from the sbt 2 migration in #347, and it is my mistake.** Dropping `sbt-sonatype` also dropped the `publishTo := sonatypePublishToBundle.value` that plugin supplied, and nothing replaced it.

sbt does publish to the Central Portal without a plugin — `publishSigned; sonaRelease` was right — but it does **not** wire that up for you. It defines a `localStaging` resolver and leaves `publishTo :== None`; `sonaRelease` then zips whatever is in `target/sona-staging` and uploads that. Confirmed in the sbt 2.0.7 jars, and against sbt's own `build.sbt`, the [2.x recipe](https://www.scala-sbt.org/2.x/docs/en/recipes/central.html), giter8 and xuwei-k/unused-code, which all set it by hand.

Nothing reached Maven Central — this fails before anything is signed, and `fs2-compress-gzip_3/3.0.0/` is a 404. Central still ends at 2.3.2.

## The fix

```scala
publishTo := {
  val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
  if (version.value.endsWith("-SNAPSHOT")) Some("central-snapshots" at centralSnapshots)
  else localStaging.value
},
```

Both branches are needed: a build with no tag is `0.0.1-SNAPSHOT`, the Portal takes snapshots directly rather than through a bundle, and `sonaRelease` refuses a snapshot outright.

## The guard

Green CI proved nothing about publishing, because that path only runs during a release. Every push now runs everything a release does apart from the upload:

```yaml
- name: Check the release path
  if: github.event_name == 'push'
  run: sbt "; set every publishTo := localStaging.value ; publishSigned; sonaBundle"
```

`publishTo` is **pinned** here rather than derived, and that is load-bearing. Two ways it could otherwise have published for real:

1. Without a tag the version is a snapshot, so the derived `publishTo` is the live Sonatype snapshot repository — a dry run would have uploaded on every push.
2. sbt 2's server reads `sys.env` once at load. The `Test` step starts it, so a later step setting `CI_VERSION` to something else has no effect — it connects to the running server and keeps the old value. I hit this locally while verifying, which is how it was caught.

Pinning the resolver removes both. Neither `sonaUpload` nor `sonaRelease` is reachable from this step.

## Verification

Locally, with no signing key and without contacting Sonatype:

- `publishTo` with no `CI_VERSION` → `central-snapshots`, version `0.0.1-SNAPSHOT`.
- `publishTo` with `CI_VERSION=refs/tags/0.0.0-DRYRUN` → `local-staging` at `target/sona-staging`, version `0.0.0-DRYRUN`. These two are the bug, fixed.
- A full `publish; sonaBundle` staged **39 poms and 117 jars** — main, sources and javadoc for every row — and produced a 548-file `bundle.zip`, each artifact with its pom and checksums.

In CI, this branch's push run exercises `publishSigned` for the first time since the migration, so it also answers whether the signing key needs a passphrase the workflow does not supply.

## Releasing

Ship as **3.0.1** once this lands; 3.0.0's tag and release stay as they are, since nothing was ever published under that version.
